### PR TITLE
Add port-aware certificate observations

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -4,7 +4,7 @@ cert-observatory Database Schema (PostgreSQL)
 Purpose:
 - Catalog TLS certificates (deduplicated by hash)
 - Store exact peer-provided certificate chains (deduplicated)
-- Track latest chain per domain plus historical unique chains ever observed
+- Track latest chain per domain/port plus historical unique chains ever observed
 - Track rate limiting timestamps and basic failure/backoff for automated crawling
 
 Non-goals:
@@ -14,15 +14,15 @@ Non-goals:
 Assumptions:
 - Domain normalization occurs in the application layer (lowercase, no trailing dot)
 - Crawling is TLS-only and SNI is always used
-- Port is implicitly 443 for now
+- Port defaults to 443 and is part of the crawl target identity
 - Certificate hash is sha256 over DER bytes, stored as 32-byte bytea
 - Chain hash is sha256 over the ordered list of certificate hashes (application-defined encoding)
 
 Recommended transaction pattern:
 - Insert missing certificates (upsert by hash)
 - Insert missing chain (upsert by hash)
-- Update domain current_chain_hash and timestamps
-- Upsert domain_chains association
+- Update domain/port current_chain_hash and timestamps
+- Upsert domain_chains association for the domain/port
 */
 
 BEGIN;
@@ -145,8 +145,9 @@ CREATE INDEX IF NOT EXISTS idx_chains_cert_hashes
 ----------------------------
 
 CREATE TABLE IF NOT EXISTS domains (
-  -- Normalized domain string as primary key
-  domain text PRIMARY KEY,
+  -- Normalized domain string plus TCP port identify the crawl target
+  domain text NOT NULL,
+  port integer NOT NULL DEFAULT 443,
 
   first_seen_at timestamptz NOT NULL DEFAULT now(),
 
@@ -179,12 +180,16 @@ CREATE TABLE IF NOT EXISTS domains (
   -- Light DB-side guards. Full validation and canonicalization occurs in the application.
   CHECK (domain = lower(domain)),
   CHECK (right(domain, 1) <> '.'),
-  CHECK (length(domain) BETWEEN 1 AND 253)
+  CHECK (length(domain) BETWEEN 1 AND 253),
+  CHECK (port BETWEEN 1 AND 65535),
+
+  PRIMARY KEY (domain, port)
 );
 
 COMMENT ON TABLE domains IS
-'Normalized domain targets (TLS SNI). Stores latest chain pointer, rate limit timestamps, and automated backoff state.';
-COMMENT ON COLUMN domains.domain IS 'Normalized domain (lowercase, no trailing dot). Primary key.';
+'Normalized domain targets (TLS SNI plus TCP port). Stores latest chain pointer, rate limit timestamps, and automated backoff state.';
+COMMENT ON COLUMN domains.domain IS 'Normalized domain (lowercase, no trailing dot).';
+COMMENT ON COLUMN domains.port IS 'TCP port used for TLS certificate observation. Defaults to 443.';
 COMMENT ON COLUMN domains.popular_domain IS 'True if the domain ever appeared on an imported popular list.';
 COMMENT ON COLUMN domains.auto_crawl IS 'True if automated crawling is enabled for this domain.';
 COMMENT ON COLUMN domains.current_chain_hash IS 'Latest successful chain_hash observed for this domain.';
@@ -214,8 +219,9 @@ CREATE INDEX IF NOT EXISTS idx_domains_current_chain
 ----------------------------
 
 CREATE TABLE IF NOT EXISTS domain_chains (
-  -- Composite primary key: one row per (domain, chain) pair
-  domain     text NOT NULL REFERENCES domains(domain) ON DELETE CASCADE,
+  -- Composite primary key: one row per (domain, port, chain) tuple
+  domain     text NOT NULL,
+  port       integer NOT NULL DEFAULT 443,
   chain_hash bytea NOT NULL REFERENCES chains(chain_hash) ON DELETE RESTRICT,
 
   -- When this chain was first observed for this domain
@@ -230,20 +236,23 @@ CREATE TABLE IF NOT EXISTS domain_chains (
   -- How the most recent observation was triggered
   last_mode     crawl_mode NOT NULL,
 
-  PRIMARY KEY (domain, chain_hash),
+  PRIMARY KEY (domain, port, chain_hash),
+  FOREIGN KEY (domain, port) REFERENCES domains(domain, port) ON DELETE CASCADE,
+  CHECK (port BETWEEN 1 AND 65535),
   CHECK (octet_length(chain_hash) = 32),
   CHECK (last_seen_at >= first_seen_at),
   CHECK (seen_count >= 1)
 );
 
 COMMENT ON TABLE domain_chains IS
-'One row per unique chain ever observed for a domain. No duplicates on oscillation between chains.';
+'One row per unique chain ever observed for a domain/port. No duplicates on oscillation between chains.';
+COMMENT ON COLUMN domain_chains.port IS 'TCP port used when this chain was observed for the domain.';
 COMMENT ON COLUMN domain_chains.first_seen_at IS 'When this chain was first observed for this domain.';
 COMMENT ON COLUMN domain_chains.last_seen_at IS 'When this chain was last observed for this domain.';
 COMMENT ON COLUMN domain_chains.seen_count IS 'Total number of successful observations of this chain for this domain.';
 COMMENT ON COLUMN domain_chains.last_mode IS 'How the most recent observation was triggered.';
 
--- Reverse lookup: which domains have ever served this chain
+-- Reverse lookup: which domain/port targets have ever served this chain
 CREATE INDEX IF NOT EXISTS idx_domain_chains_chain_hash
   ON domain_chains (chain_hash);
 

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -53,11 +53,12 @@ Deduplicated peer-provided chains. A chain is the ordered list returned by the s
 
 ### domains
 
-Normalized domain targets (TLS SNI). Stores latest chain pointer, rate limit timestamps, and automated backoff state.
+Normalized domain targets (TLS SNI plus TCP port). Stores latest chain pointer, rate limit timestamps, and automated backoff state.
 
 | Column | Type | Description |
 |--------|------|-------------|
 | `domain` | text (PK) | Normalized domain (lowercase, no trailing dot) |
+| `port` | integer (PK) | TCP port used for TLS observation, defaults to 443 |
 | `first_seen_at` | timestamptz | When this domain was first seen |
 | `popular_domain` | boolean | True if domain appeared on imported popular list |
 | `auto_crawl` | boolean | True if automated crawling is enabled |
@@ -74,11 +75,12 @@ Normalized domain targets (TLS SNI). Stores latest chain pointer, rate limit tim
 
 ### domain_chains
 
-One row per unique chain ever observed for a domain. No duplicates on oscillation between chains.
+One row per unique chain ever observed for a domain and port. No duplicates on oscillation between chains.
 
 | Column | Type | Description |
 |--------|------|-------------|
 | `domain` | text (PK) | Reference to domains table |
+| `port` | integer (PK) | TCP port used when this chain was observed |
 | `chain_hash` | bytea (PK) | Reference to chains table |
 | `first_seen_at` | timestamptz | When this chain was first observed for this domain |
 | `last_seen_at` | timestamptz | When this chain was last observed for this domain |
@@ -99,8 +101,8 @@ Enum indicating how a crawl was triggered:
 ### Storage Goals
 
 - **Content-addressed keys**: Certificates and chains are keyed by SHA-256 hashes
-- **Domain text as primary key**: No surrogate integer IDs for domains
-- **One row per unique chain per domain**: No duplicates when oscillating between chains
+- **Domain and port as primary key**: No surrogate integer IDs for crawl targets
+- **One row per unique chain per domain and port**: No duplicates when oscillating between chains
 
 ### Non-goals
 

--- a/docs/SERVE-WEB.md
+++ b/docs/SERVE-WEB.md
@@ -86,6 +86,7 @@ Force refresh is only available when server-side policy allows it.
 The web server includes security hardening:
 
 - Input validation and normalization for domain names
+- Port 443 is used by default. Supplying the `?port` query parameter to `/inspect` or `/refresh` enables `host:port` input such as `www.example.com:8443`.
 - CSRF protection for state-changing operations
 - SQL injection prevention via parameterized queries
 - XSS prevention via HTML escaping

--- a/docs/SERVE-WEB.md
+++ b/docs/SERVE-WEB.md
@@ -86,7 +86,6 @@ Force refresh is only available when server-side policy allows it.
 The web server includes security hardening:
 
 - Input validation and normalization for domain names
-- Port 443 is used by default. Supplying the `?port` query parameter to `/inspect` or `/refresh` enables `host:port` input such as `www.example.com:8443`.
 - CSRF protection for state-changing operations
 - SQL injection prevention via parameterized queries
 - XSS prevention via HTML escaping

--- a/internal/cmd/web_crawler.go
+++ b/internal/cmd/web_crawler.go
@@ -22,7 +22,12 @@ func NewWebCrawler(timeout time.Duration) *WebCrawler {
 
 // Crawl performs a TLS handshake and returns the certificate chain.
 func (wc *WebCrawler) Crawl(ctx context.Context, domain string) (*web.CrawlOutput, error) {
-	result, err := wc.crawler.Crawl(ctx, domain)
+	return wc.CrawlPort(ctx, domain, 443)
+}
+
+// CrawlPort performs a TLS handshake on the specified port and returns the certificate chain.
+func (wc *WebCrawler) CrawlPort(ctx context.Context, domain string, port int) (*web.CrawlOutput, error) {
+	result, err := wc.crawler.CrawlPort(ctx, domain, port)
 	if err != nil {
 		return nil, err
 	}
@@ -47,6 +52,7 @@ func (wc *WebCrawler) Crawl(ctx context.Context, domain string) (*web.CrawlOutpu
 
 	return &web.CrawlOutput{
 		Domain: domain,
+		Port:   port,
 		Chain:  chain,
 	}, nil
 }

--- a/internal/crawler/crawler.go
+++ b/internal/crawler/crawler.go
@@ -22,6 +22,8 @@ var (
 type CrawlResult struct {
 	// Domain is the normalized domain that was crawled
 	Domain string
+	// Port is the TCP port used for the TLS handshake
+	Port int
 	// ChainInfo contains the parsed certificate chain information
 	ChainInfo *certutil.ChainInfo
 	// RawCerts contains the raw x509.Certificate objects
@@ -68,6 +70,12 @@ func New(timeout time.Duration) *Crawler {
 //   - Does not send HTTP requests or follow redirects
 //   - Does not fetch OCSP/CRL or perform AIA fetching
 func (c *Crawler) Crawl(ctx context.Context, domain string) (*CrawlResult, error) {
+	return c.CrawlPort(ctx, domain, 443)
+}
+
+// CrawlPort performs a TLS handshake to the specified domain and TCP port and
+// returns the certificate chain presented by the server.
+func (c *Crawler) CrawlPort(ctx context.Context, domain string, port int) (*CrawlResult, error) {
 	crawlTime := time.Now()
 
 	// Create context with timeout if not already set
@@ -81,7 +89,7 @@ func (c *Crawler) Crawl(ctx context.Context, domain string) (*CrawlResult, error
 	dialer := &net.Dialer{}
 
 	// Dial TCP connection
-	addr := net.JoinHostPort(domain, "443")
+	addr := net.JoinHostPort(domain, fmt.Sprintf("%d", port))
 	conn, err := dialer.DialContext(ctx, "tcp", addr)
 	if err != nil {
 		return nil, &CrawlError{Domain: domain, Err: fmt.Errorf("tcp connect: %w", err)}
@@ -124,6 +132,7 @@ func (c *Crawler) Crawl(ctx context.Context, domain string) (*CrawlResult, error
 
 	return &CrawlResult{
 		Domain:    domain,
+		Port:      port,
 		ChainInfo: chainInfo,
 		RawCerts:  state.PeerCertificates,
 		CrawlTime: crawlTime,

--- a/internal/db/auto_crawl_repository.go
+++ b/internal/db/auto_crawl_repository.go
@@ -73,6 +73,7 @@ func (r *Repository) GetEligibleDomainsForCrawl(ctx context.Context, effectiveAg
 		SELECT domain
 		FROM domains
 		WHERE auto_crawl = true
+		  AND port = 443
 		  AND (no_retry_before IS NULL OR no_retry_before <= now())
 		  AND (last_success_at IS NULL OR last_success_at <= $1)
 		ORDER BY
@@ -114,6 +115,7 @@ func (r *Repository) GetEligibleDomainsForCrawl(ctx context.Context, effectiveAg
 func (r *Repository) RecordAutoCrawlSuccess(ctx context.Context, domain string, chainInfo *certutil.ChainInfo, crawlTime time.Time) (*CrawlStats, error) {
 	result := &CrawlResult{
 		Domain:    domain,
+		Port:      443,
 		ChainInfo: chainInfo,
 		CrawlTime: crawlTime,
 		Mode:      CrawlModeAuto,
@@ -126,7 +128,7 @@ func (r *Repository) RecordAutoCrawlSuccess(ctx context.Context, domain string, 
 
 	// Also clear no_retry_before explicitly for auto mode
 	_, err = r.db.ExecContext(ctx, `
-		UPDATE domains SET no_retry_before = NULL WHERE domain = $1
+		UPDATE domains SET no_retry_before = NULL WHERE domain = $1 AND port = 443
 	`, domain)
 	if err != nil {
 		return nil, fmt.Errorf("clear no_retry_before: %w", err)
@@ -144,7 +146,7 @@ func (r *Repository) RecordAutoCrawlFailure(ctx context.Context, domain string, 
 	defer tx.Rollback()
 
 	// Upsert domain
-	_, _, err = r.upsertDomain(ctx, tx, domain)
+	_, _, err = r.upsertDomain(ctx, tx, domain, 443)
 	if err != nil {
 		return time.Time{}, 0, fmt.Errorf("upsert domain: %w", err)
 	}
@@ -152,7 +154,7 @@ func (r *Repository) RecordAutoCrawlFailure(ctx context.Context, domain string, 
 	// Get current consecutive failures and increment
 	var currentFailures int
 	err = tx.QueryRowContext(ctx, `
-		SELECT consecutive_failures FROM domains WHERE domain = $1
+		SELECT consecutive_failures FROM domains WHERE domain = $1 AND port = 443
 	`, domain).Scan(&currentFailures)
 	if err != nil && err != sql.ErrNoRows {
 		return time.Time{}, 0, fmt.Errorf("get consecutive failures: %w", err)
@@ -168,7 +170,7 @@ func (r *Repository) RecordAutoCrawlFailure(ctx context.Context, domain string, 
 			last_failure_at = $2,
 			consecutive_failures = $3,
 			no_retry_before = $4
-		WHERE domain = $1
+		WHERE domain = $1 AND port = 443
 	`, domain, crawlTime, newFailures, noRetryBefore)
 	if err != nil {
 		return time.Time{}, 0, fmt.Errorf("update domain failure: %w", err)
@@ -190,6 +192,7 @@ func (r *Repository) CountEligibleDomains(ctx context.Context, effectiveAge time
 		SELECT COUNT(*)
 		FROM domains
 		WHERE auto_crawl = true
+		  AND port = 443
 		  AND (no_retry_before IS NULL OR no_retry_before <= now())
 		  AND (last_success_at IS NULL OR last_success_at <= $1)
 	`, threshold).Scan(&count)
@@ -205,7 +208,7 @@ func (r *Repository) CountEligibleDomainsWithOptions(ctx context.Context, effect
 	threshold := time.Now().Add(-effectiveAge)
 
 	// Build the query dynamically based on options
-	query := `SELECT COUNT(*) FROM domains WHERE auto_crawl = true`
+	query := `SELECT COUNT(*) FROM domains WHERE auto_crawl = true AND port = 443`
 
 	// Handle backoff logic
 	if !opts.IgnoreErrors {
@@ -233,7 +236,7 @@ func (r *Repository) GetEligibleDomainsForCrawlWithOptions(ctx context.Context, 
 	threshold := time.Now().Add(-effectiveAge)
 
 	// Build the query dynamically based on options
-	query := `SELECT domain FROM domains WHERE auto_crawl = true`
+	query := `SELECT domain FROM domains WHERE auto_crawl = true AND port = 443`
 
 	// Handle backoff logic
 	if !opts.IgnoreErrors {
@@ -295,14 +298,14 @@ func (r *Repository) UpsertDomainFromToplist(ctx context.Context, domain string)
 	err = tx.QueryRowContext(ctx, `
 		SELECT popular_domain, auto_crawl
 		FROM domains
-		WHERE domain = $1
+		WHERE domain = $1 AND port = 443
 	`, domain).Scan(&popularDomain, &autoCrawl)
 
 	if err == sql.ErrNoRows {
 		// Insert new domain
 		_, err = tx.ExecContext(ctx, `
-			INSERT INTO domains (domain, first_seen_at, popular_domain, auto_crawl)
-			VALUES ($1, now(), true, true)
+			INSERT INTO domains (domain, port, first_seen_at, popular_domain, auto_crawl)
+			VALUES ($1, 443, now(), true, true)
 		`, domain)
 		if err != nil {
 			return false, false, fmt.Errorf("insert domain: %w", err)
@@ -322,7 +325,7 @@ func (r *Repository) UpsertDomainFromToplist(ctx context.Context, domain string)
 	needsUpdate := !popularDomain || !autoCrawl
 	if needsUpdate {
 		_, err = tx.ExecContext(ctx, `
-			UPDATE domains SET popular_domain = true, auto_crawl = true WHERE domain = $1
+			UPDATE domains SET popular_domain = true, auto_crawl = true WHERE domain = $1 AND port = 443
 		`, domain)
 		if err != nil {
 			return false, false, fmt.Errorf("update domain: %w", err)
@@ -358,14 +361,14 @@ func (r *Repository) BulkUpsertDomainsFromToplist(ctx context.Context, domains [
 		err = tx.QueryRowContext(ctx, `
 			SELECT popular_domain, auto_crawl
 			FROM domains
-			WHERE domain = $1
+			WHERE domain = $1 AND port = 443
 		`, domain).Scan(&popularDomain, &autoCrawl)
 
 		if err == sql.ErrNoRows {
 			// Insert new domain
 			_, err = tx.ExecContext(ctx, `
-				INSERT INTO domains (domain, first_seen_at, popular_domain, auto_crawl)
-				VALUES ($1, now(), true, true)
+				INSERT INTO domains (domain, port, first_seen_at, popular_domain, auto_crawl)
+				VALUES ($1, 443, now(), true, true)
 			`, domain)
 			if err != nil {
 				return inserted, updated, fmt.Errorf("insert domain %s: %w", domain, err)
@@ -382,7 +385,7 @@ func (r *Repository) BulkUpsertDomainsFromToplist(ctx context.Context, domains [
 		needsUpdate := !popularDomain || !autoCrawl
 		if needsUpdate {
 			_, err = tx.ExecContext(ctx, `
-				UPDATE domains SET popular_domain = true, auto_crawl = true WHERE domain = $1
+				UPDATE domains SET popular_domain = true, auto_crawl = true WHERE domain = $1 AND port = 443
 			`, domain)
 			if err != nil {
 				return inserted, updated, fmt.Errorf("update domain %s: %w", domain, err)

--- a/internal/db/migrate.go
+++ b/internal/db/migrate.go
@@ -14,7 +14,7 @@ import (
 var migrations embed.FS
 
 // ExpectedVersion is the expected migration version for this binary.
-const ExpectedVersion = 1
+const ExpectedVersion = 2
 
 // RunMigrations runs all pending database migrations.
 func RunMigrations(db *sql.DB) error {

--- a/internal/db/migrations/000002_domain_ports.down.sql
+++ b/internal/db/migrations/000002_domain_ports.down.sql
@@ -1,0 +1,33 @@
+ALTER TABLE domain_chains
+  DROP CONSTRAINT IF EXISTS domain_chains_domain_port_fkey;
+
+DELETE FROM domain_chains WHERE port <> 443;
+DELETE FROM domains WHERE port <> 443;
+
+ALTER TABLE domain_chains
+  DROP CONSTRAINT IF EXISTS domain_chains_pkey;
+
+ALTER TABLE domains
+  DROP CONSTRAINT IF EXISTS domains_pkey;
+
+ALTER TABLE domains
+  ADD PRIMARY KEY (domain);
+
+ALTER TABLE domain_chains
+  ADD PRIMARY KEY (domain, chain_hash);
+
+ALTER TABLE domain_chains
+  ADD CONSTRAINT domain_chains_domain_fkey
+  FOREIGN KEY (domain) REFERENCES domains(domain) ON DELETE CASCADE;
+
+ALTER TABLE domain_chains
+  DROP CONSTRAINT IF EXISTS domain_chains_port_check;
+
+ALTER TABLE domain_chains
+  DROP COLUMN IF EXISTS port;
+
+ALTER TABLE domains
+  DROP CONSTRAINT IF EXISTS domains_port_check;
+
+ALTER TABLE domains
+  DROP COLUMN IF EXISTS port;

--- a/internal/db/migrations/000002_domain_ports.up.sql
+++ b/internal/db/migrations/000002_domain_ports.up.sql
@@ -1,0 +1,33 @@
+ALTER TABLE domain_chains
+  DROP CONSTRAINT IF EXISTS domain_chains_domain_fkey;
+
+ALTER TABLE domains
+  ADD COLUMN IF NOT EXISTS port integer NOT NULL DEFAULT 443;
+
+ALTER TABLE domains
+  ADD CONSTRAINT domains_port_check CHECK (port BETWEEN 1 AND 65535);
+
+ALTER TABLE domains
+  DROP CONSTRAINT IF EXISTS domains_pkey;
+
+ALTER TABLE domains
+  ADD PRIMARY KEY (domain, port);
+
+ALTER TABLE domain_chains
+  ADD COLUMN IF NOT EXISTS port integer NOT NULL DEFAULT 443;
+
+ALTER TABLE domain_chains
+  ADD CONSTRAINT domain_chains_port_check CHECK (port BETWEEN 1 AND 65535);
+
+ALTER TABLE domain_chains
+  DROP CONSTRAINT IF EXISTS domain_chains_pkey;
+
+ALTER TABLE domain_chains
+  ADD PRIMARY KEY (domain, port, chain_hash);
+
+ALTER TABLE domain_chains
+  ADD CONSTRAINT domain_chains_domain_port_fkey
+  FOREIGN KEY (domain, port) REFERENCES domains(domain, port) ON DELETE CASCADE;
+
+COMMENT ON COLUMN domains.port IS 'TCP port used for TLS certificate observation. Defaults to 443.';
+COMMENT ON COLUMN domain_chains.port IS 'TCP port used when this chain was observed for the domain.';

--- a/internal/db/repository.go
+++ b/internal/db/repository.go
@@ -23,6 +23,7 @@ const (
 // CrawlResult represents the result to be stored from a crawl operation.
 type CrawlResult struct {
 	Domain    string
+	Port      int
 	ChainInfo *certutil.ChainInfo
 	CrawlTime time.Time
 	Mode      CrawlMode
@@ -30,13 +31,13 @@ type CrawlResult struct {
 
 // CrawlStats contains information about what was created/updated during a crawl.
 type CrawlStats struct {
-	DomainInserted       bool
-	CertsInserted        int
-	ChainInserted        bool
-	DomainChainUpdated   bool
-	DomainChainInserted  bool
-	CurrentChainChanged  bool
-	PreviousChainHash    []byte
+	DomainInserted      bool
+	CertsInserted       int
+	ChainInserted       bool
+	DomainChainUpdated  bool
+	DomainChainInserted bool
+	CurrentChainChanged bool
+	PreviousChainHash   []byte
 }
 
 // Repository provides database operations for certificate crawling.
@@ -60,7 +61,9 @@ func (r *Repository) RecordSuccessfulCrawl(ctx context.Context, result *CrawlRes
 	stats := &CrawlStats{}
 
 	// Step 1: Upsert domain
-	inserted, previousChainHash, err := r.upsertDomain(ctx, tx, result.Domain)
+	port := normalizePort(result.Port)
+
+	inserted, previousChainHash, err := r.upsertDomain(ctx, tx, result.Domain, port)
 	if err != nil {
 		return nil, fmt.Errorf("upsert domain: %w", err)
 	}
@@ -82,14 +85,14 @@ func (r *Repository) RecordSuccessfulCrawl(ctx context.Context, result *CrawlRes
 	stats.ChainInserted = chainInserted
 
 	// Step 4: Update domain current chain and timestamps
-	chainChanged, err := r.updateDomainSuccess(ctx, tx, result.Domain, result.ChainInfo.ChainHash, result.CrawlTime, result.Mode)
+	chainChanged, err := r.updateDomainSuccess(ctx, tx, result.Domain, port, result.ChainInfo.ChainHash, result.CrawlTime, result.Mode)
 	if err != nil {
 		return nil, fmt.Errorf("update domain: %w", err)
 	}
 	stats.CurrentChainChanged = chainChanged
 
 	// Step 5: Upsert domain_chains association
-	dcInserted, err := r.upsertDomainChain(ctx, tx, result.Domain, result.ChainInfo.ChainHash, result.CrawlTime, result.Mode)
+	dcInserted, err := r.upsertDomainChain(ctx, tx, result.Domain, port, result.ChainInfo.ChainHash, result.CrawlTime, result.Mode)
 	if err != nil {
 		return nil, fmt.Errorf("upsert domain chain: %w", err)
 	}
@@ -104,14 +107,14 @@ func (r *Repository) RecordSuccessfulCrawl(ctx context.Context, result *CrawlRes
 }
 
 // upsertDomain ensures a domain row exists and returns whether it was inserted and its previous chain hash.
-func (r *Repository) upsertDomain(ctx context.Context, tx *sql.Tx, domain string) (bool, []byte, error) {
+func (r *Repository) upsertDomain(ctx context.Context, tx *sql.Tx, domain string, port int) (bool, []byte, error) {
 	// First, try to get existing domain
 	var previousChainHash []byte
 	err := tx.QueryRowContext(ctx, `
 		SELECT current_chain_hash
 		FROM domains
-		WHERE domain = $1
-	`, domain).Scan(&previousChainHash)
+		WHERE domain = $1 AND port = $2
+	`, domain, port).Scan(&previousChainHash)
 
 	if err == nil {
 		// Domain exists
@@ -124,9 +127,9 @@ func (r *Repository) upsertDomain(ctx context.Context, tx *sql.Tx, domain string
 
 	// Insert new domain
 	_, err = tx.ExecContext(ctx, `
-		INSERT INTO domains (domain, first_seen_at)
-		VALUES ($1, now())
-	`, domain)
+		INSERT INTO domains (domain, port, first_seen_at)
+		VALUES ($1, $2, now())
+	`, domain, port)
 
 	if err != nil {
 		return false, nil, fmt.Errorf("insert domain: %w", err)
@@ -183,11 +186,11 @@ func (r *Repository) insertChain(ctx context.Context, tx *sql.Tx, chainInfo *cer
 }
 
 // updateDomainSuccess updates domain timestamps for a successful crawl.
-func (r *Repository) updateDomainSuccess(ctx context.Context, tx *sql.Tx, domain string, chainHash []byte, crawlTime time.Time, mode CrawlMode) (bool, error) {
+func (r *Repository) updateDomainSuccess(ctx context.Context, tx *sql.Tx, domain string, port int, chainHash []byte, crawlTime time.Time, mode CrawlMode) (bool, error) {
 	var currentChainHash []byte
 	err := tx.QueryRowContext(ctx, `
-		SELECT current_chain_hash FROM domains WHERE domain = $1
-	`, domain).Scan(&currentChainHash)
+		SELECT current_chain_hash FROM domains WHERE domain = $1 AND port = $2
+	`, domain, port).Scan(&currentChainHash)
 	if err != nil && err != sql.ErrNoRows {
 		return false, fmt.Errorf("get current chain: %w", err)
 	}
@@ -206,7 +209,7 @@ func (r *Repository) updateDomainSuccess(ctx context.Context, tx *sql.Tx, domain
 				last_standard_attempt_at = $3,
 				last_standard_success_at = $3,
 				consecutive_failures = 0
-			WHERE domain = $1
+			WHERE domain = $1 AND port = $4
 		`
 	case CrawlModeForced:
 		query = `
@@ -217,7 +220,7 @@ func (r *Repository) updateDomainSuccess(ctx context.Context, tx *sql.Tx, domain
 				last_forced_attempt_at = $3,
 				last_forced_success_at = $3,
 				consecutive_failures = 0
-			WHERE domain = $1
+			WHERE domain = $1 AND port = $4
 		`
 	case CrawlModeAuto:
 		// Auto mode also updates standard timestamps so web interface
@@ -231,7 +234,7 @@ func (r *Repository) updateDomainSuccess(ctx context.Context, tx *sql.Tx, domain
 				last_standard_success_at = $3,
 				consecutive_failures = 0,
 				no_retry_before = NULL
-			WHERE domain = $1
+			WHERE domain = $1 AND port = $4
 		`
 	default:
 		query = `
@@ -240,11 +243,11 @@ func (r *Repository) updateDomainSuccess(ctx context.Context, tx *sql.Tx, domain
 				current_chain_updated_at = $3,
 				last_success_at = $3,
 				consecutive_failures = 0
-			WHERE domain = $1
+			WHERE domain = $1 AND port = $4
 		`
 	}
 
-	_, err = tx.ExecContext(ctx, query, domain, chainHash, crawlTime)
+	_, err = tx.ExecContext(ctx, query, domain, chainHash, crawlTime, port)
 	if err != nil {
 		return false, fmt.Errorf("update domain: %w", err)
 	}
@@ -254,7 +257,7 @@ func (r *Repository) updateDomainSuccess(ctx context.Context, tx *sql.Tx, domain
 
 // upsertDomainChain upserts the domain_chains association.
 // Returns true if a new row was inserted, false if an existing row was updated.
-func (r *Repository) upsertDomainChain(ctx context.Context, tx *sql.Tx, domain string, chainHash []byte, crawlTime time.Time, mode CrawlMode) (bool, error) {
+func (r *Repository) upsertDomainChain(ctx context.Context, tx *sql.Tx, domain string, port int, chainHash []byte, crawlTime time.Time, mode CrawlMode) (bool, error) {
 	// Try to update existing row first
 	result, err := tx.ExecContext(ctx, `
 		UPDATE domain_chains SET
@@ -262,7 +265,8 @@ func (r *Repository) upsertDomainChain(ctx context.Context, tx *sql.Tx, domain s
 			seen_count = seen_count + 1,
 			last_mode = $4
 		WHERE domain = $1 AND chain_hash = $2
-	`, domain, chainHash, crawlTime, mode)
+			AND port = $5
+	`, domain, chainHash, crawlTime, mode, port)
 	if err != nil {
 		return false, fmt.Errorf("update domain_chain: %w", err)
 	}
@@ -279,9 +283,9 @@ func (r *Repository) upsertDomainChain(ctx context.Context, tx *sql.Tx, domain s
 
 	// Insert new row
 	_, err = tx.ExecContext(ctx, `
-		INSERT INTO domain_chains (domain, chain_hash, first_seen_at, last_seen_at, seen_count, last_mode)
-		VALUES ($1, $2, $3, $3, 1, $4)
-	`, domain, chainHash, crawlTime, mode)
+		INSERT INTO domain_chains (domain, port, chain_hash, first_seen_at, last_seen_at, seen_count, last_mode)
+		VALUES ($1, $2, $3, $4, $4, 1, $5)
+	`, domain, port, chainHash, crawlTime, mode)
 	if err != nil {
 		return true, fmt.Errorf("insert domain_chain: %w", err)
 	}
@@ -291,6 +295,11 @@ func (r *Repository) upsertDomainChain(ctx context.Context, tx *sql.Tx, domain s
 
 // RecordFailedCrawl records a failed crawl attempt.
 func (r *Repository) RecordFailedCrawl(ctx context.Context, domain string, crawlTime time.Time, mode CrawlMode) error {
+	return r.RecordFailedCrawlForPort(ctx, domain, 443, crawlTime, mode)
+}
+
+// RecordFailedCrawlForPort records a failed crawl attempt for a domain and port.
+func (r *Repository) RecordFailedCrawlForPort(ctx context.Context, domain string, port int, crawlTime time.Time, mode CrawlMode) error {
 	tx, err := r.db.BeginTx(ctx)
 	if err != nil {
 		return fmt.Errorf("begin transaction: %w", err)
@@ -298,7 +307,7 @@ func (r *Repository) RecordFailedCrawl(ctx context.Context, domain string, crawl
 	defer tx.Rollback()
 
 	// Upsert domain
-	_, _, err = r.upsertDomain(ctx, tx, domain)
+	_, _, err = r.upsertDomain(ctx, tx, domain, normalizePort(port))
 	if err != nil {
 		return fmt.Errorf("upsert domain: %w", err)
 	}
@@ -312,7 +321,7 @@ func (r *Repository) RecordFailedCrawl(ctx context.Context, domain string, crawl
 				last_failure_at = $2,
 				consecutive_failures = consecutive_failures + 1,
 				last_standard_attempt_at = $2
-			WHERE domain = $1
+			WHERE domain = $1 AND port = $3
 		`
 	case CrawlModeForced:
 		query = `
@@ -320,18 +329,18 @@ func (r *Repository) RecordFailedCrawl(ctx context.Context, domain string, crawl
 				last_failure_at = $2,
 				consecutive_failures = consecutive_failures + 1,
 				last_forced_attempt_at = $2
-			WHERE domain = $1
+			WHERE domain = $1 AND port = $3
 		`
 	default:
 		query = `
 			UPDATE domains SET
 				last_failure_at = $2,
 				consecutive_failures = consecutive_failures + 1
-			WHERE domain = $1
+			WHERE domain = $1 AND port = $3
 		`
 	}
 
-	_, err = tx.ExecContext(ctx, query, domain, crawlTime)
+	_, err = tx.ExecContext(ctx, query, domain, crawlTime, normalizePort(port))
 	if err != nil {
 		return fmt.Errorf("update domain failure: %w", err)
 	}
@@ -341,6 +350,13 @@ func (r *Repository) RecordFailedCrawl(ctx context.Context, domain string, crawl
 	}
 
 	return nil
+}
+
+func normalizePort(port int) int {
+	if port == 0 {
+		return 443
+	}
+	return port
 }
 
 // nullableBytes returns nil if the slice is empty, otherwise returns the slice.

--- a/internal/db/web_repository.go
+++ b/internal/db/web_repository.go
@@ -28,8 +28,14 @@ func NewWebRepository(db *DB) *WebRepository {
 
 // GetDomainWithChain retrieves a domain and its current chain with certificates.
 func (r *WebRepository) GetDomainWithChain(ctx context.Context, domainName string) (*web.DomainResult, error) {
+	return r.GetDomainWithChainForPort(ctx, domainName, 443)
+}
+
+// GetDomainWithChainForPort retrieves a domain target and its current chain with certificates.
+func (r *WebRepository) GetDomainWithChainForPort(ctx context.Context, domainName string, port int) (*web.DomainResult, error) {
 	result := &web.DomainResult{
 		Domain: domainName,
+		Port:   port,
 	}
 
 	// Get domain info
@@ -39,8 +45,8 @@ func (r *WebRepository) GetDomainWithChain(ctx context.Context, domainName strin
 	err := r.db.QueryRowContext(ctx, `
 		SELECT current_chain_hash, current_chain_updated_at
 		FROM domains
-		WHERE domain = $1
-	`, domainName).Scan(&chainHash, &updatedAt)
+		WHERE domain = $1 AND port = $2
+	`, domainName, port).Scan(&chainHash, &updatedAt)
 
 	if err == sql.ErrNoRows {
 		return result, nil
@@ -153,13 +159,18 @@ func (r *WebRepository) GetCertificateByHash(ctx context.Context, hash []byte) (
 
 // CanStandardRefresh checks if a standard refresh is allowed for the domain.
 func (r *WebRepository) CanStandardRefresh(ctx context.Context, domainName string, window time.Duration) (bool, time.Duration, error) {
+	return r.CanStandardRefreshForPort(ctx, domainName, 443, window)
+}
+
+// CanStandardRefreshForPort checks if a standard refresh is allowed for the domain target.
+func (r *WebRepository) CanStandardRefreshForPort(ctx context.Context, domainName string, port int, window time.Duration) (bool, time.Duration, error) {
 	var lastAttempt sql.NullTime
 
 	err := r.db.QueryRowContext(ctx, `
 		SELECT last_standard_attempt_at
 		FROM domains
-		WHERE domain = $1
-	`, domainName).Scan(&lastAttempt)
+		WHERE domain = $1 AND port = $2
+	`, domainName, port).Scan(&lastAttempt)
 
 	if err == sql.ErrNoRows {
 		// Domain doesn't exist, allow refresh
@@ -184,13 +195,18 @@ func (r *WebRepository) CanStandardRefresh(ctx context.Context, domainName strin
 
 // CanForcedRefresh checks if a forced refresh is allowed for the domain.
 func (r *WebRepository) CanForcedRefresh(ctx context.Context, domainName string, window time.Duration) (bool, time.Duration, error) {
+	return r.CanForcedRefreshForPort(ctx, domainName, 443, window)
+}
+
+// CanForcedRefreshForPort checks if a forced refresh is allowed for the domain target.
+func (r *WebRepository) CanForcedRefreshForPort(ctx context.Context, domainName string, port int, window time.Duration) (bool, time.Duration, error) {
 	var lastAttempt sql.NullTime
 
 	err := r.db.QueryRowContext(ctx, `
 		SELECT last_forced_attempt_at
 		FROM domains
-		WHERE domain = $1
-	`, domainName).Scan(&lastAttempt)
+		WHERE domain = $1 AND port = $2
+	`, domainName, port).Scan(&lastAttempt)
 
 	if err == sql.ErrNoRows {
 		// Domain doesn't exist, allow refresh
@@ -216,6 +232,11 @@ func (r *WebRepository) CanForcedRefresh(ctx context.Context, domainName string,
 // AcquireLock tries to acquire a crawl lock for the domain using PostgreSQL advisory locks.
 // This is a no-op since we've removed the domain_locks table and rely on idempotent upserts.
 func (r *WebRepository) AcquireLock(ctx context.Context, domainName string, lockID string, ttl time.Duration) (bool, error) {
+	return r.AcquireLockForPort(ctx, domainName, 443, lockID, ttl)
+}
+
+// AcquireLockForPort tries to acquire a crawl lock for the domain target.
+func (r *WebRepository) AcquireLockForPort(ctx context.Context, domainName string, port int, lockID string, ttl time.Duration) (bool, error) {
 	// With the simplified schema, we rely on idempotent upserts instead of explicit locks.
 	// All database writes (certificate inserts, chain inserts, domain updates, domain_chains upserts)
 	// are idempotent and use ON CONFLICT clauses, so concurrent crawls are safe.
@@ -226,6 +247,11 @@ func (r *WebRepository) AcquireLock(ctx context.Context, domainName string, lock
 // ReleaseLock releases a crawl lock for the domain.
 // This is a no-op since we've removed the domain_locks table.
 func (r *WebRepository) ReleaseLock(ctx context.Context, domainName string, lockID string) error {
+	return r.ReleaseLockForPort(ctx, domainName, 443, lockID)
+}
+
+// ReleaseLockForPort releases a crawl lock for the domain target.
+func (r *WebRepository) ReleaseLockForPort(ctx context.Context, domainName string, port int, lockID string) error {
 	// No-op: locks are no longer used
 	return nil
 }
@@ -238,7 +264,7 @@ func (r *WebRepository) RecordCrawlResult(ctx context.Context, input *web.CrawlR
 		if input.Forced {
 			mode = CrawlModeForced
 		}
-		return r.repo.RecordFailedCrawl(ctx, input.Domain, time.Now(), mode)
+		return r.repo.RecordFailedCrawlForPort(ctx, input.Domain, input.Port, time.Now(), mode)
 	}
 
 	// Convert web types to internal types
@@ -274,6 +300,7 @@ func (r *WebRepository) RecordCrawlResult(ctx context.Context, input *web.CrawlR
 
 	result := &CrawlResult{
 		Domain:    input.Domain,
+		Port:      input.Port,
 		ChainInfo: chainInfo,
 		CrawlTime: time.Now(),
 		Mode:      mode,

--- a/internal/domain/domain.go
+++ b/internal/domain/domain.go
@@ -5,6 +5,7 @@ package domain
 import (
 	"errors"
 	"regexp"
+	"strconv"
 	"strings"
 	"unicode"
 )
@@ -18,6 +19,8 @@ var (
 	ErrDomainHasScheme = errors.New("domain must not contain a URL scheme (e.g., https://)")
 	// ErrDomainHasPort indicates the input contains a port specification
 	ErrDomainHasPort = errors.New("domain must not contain a port")
+	// ErrInvalidPort indicates the input contains an invalid port specification
+	ErrInvalidPort = errors.New("invalid port")
 	// ErrDomainHasPath indicates the input contains a path
 	ErrDomainHasPath = errors.New("domain must not contain a path")
 	// ErrDomainHasQuery indicates the input contains a query string
@@ -33,6 +36,14 @@ var (
 	// ErrDomainLabelTooLong indicates a label exceeds 63 characters
 	ErrDomainLabelTooLong = errors.New("domain label exceeds maximum length of 63 characters")
 )
+
+const DefaultPort = 443
+
+// Target is a normalized TLS crawl target.
+type Target struct {
+	Domain string
+	Port   int
+}
 
 // validHostnameChars matches valid hostname characters (alphanumeric, hyphen)
 var validHostnameChars = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]*[a-z0-9])?$`)
@@ -62,27 +73,38 @@ var schemePattern = regexp.MustCompile(`(?i)^[a-z][a-z0-9+.-]*://`)
 //   - Must contain only valid hostname characters
 //   - Each label must be 1-63 characters
 func NormalizeAndValidate(input string) (string, error) {
+	target, err := NormalizeAndValidateTarget(input, false)
+	if err != nil {
+		return "", err
+	}
+	return target.Domain, nil
+}
+
+// NormalizeAndValidateTarget takes a raw domain input, normalizes it, and
+// validates it as a TLS target. When allowPort is true, the input may include a
+// numeric port using host:port syntax.
+func NormalizeAndValidateTarget(input string, allowPort bool) (*Target, error) {
 	// Normalize: trim whitespace
 	trimmed := strings.TrimSpace(input)
 	if trimmed == "" {
-		return "", ErrEmptyDomain
+		return nil, ErrEmptyDomain
 	}
 
 	// Check for control characters before any other processing
 	for _, r := range trimmed {
 		if unicode.IsControl(r) {
-			return "", ErrDomainControlChars
+			return nil, ErrDomainControlChars
 		}
 	}
 
 	// Check for whitespace in the middle
 	if strings.ContainsAny(trimmed, " \t\n\r") {
-		return "", ErrDomainInvalidChars
+		return nil, ErrDomainInvalidChars
 	}
 
 	// Check for URL scheme
 	if schemePattern.MatchString(trimmed) {
-		return "", ErrDomainHasScheme
+		return nil, ErrDomainHasScheme
 	}
 
 	// Also check for common schemes without the full regex (e.g., "http://", "https://")
@@ -90,22 +112,31 @@ func NormalizeAndValidate(input string) (string, error) {
 	if strings.HasPrefix(lowerTrimmed, "http://") ||
 		strings.HasPrefix(lowerTrimmed, "https://") ||
 		strings.HasPrefix(lowerTrimmed, "ftp://") {
-		return "", ErrDomainHasScheme
+		return nil, ErrDomainHasScheme
 	}
 
 	// Check for path (contains /)
 	if strings.Contains(trimmed, "/") {
-		return "", ErrDomainHasPath
+		return nil, ErrDomainHasPath
 	}
 
 	// Check for query string
 	if strings.Contains(trimmed, "?") {
-		return "", ErrDomainHasQuery
+		return nil, ErrDomainHasQuery
 	}
 
-	// Check for port (contains :)
+	port := DefaultPort
+
 	if strings.Contains(trimmed, ":") {
-		return "", ErrDomainHasPort
+		if !allowPort {
+			return nil, ErrDomainHasPort
+		}
+		host, parsedPort, err := splitHostPort(trimmed)
+		if err != nil {
+			return nil, err
+		}
+		trimmed = host
+		port = parsedPort
 	}
 
 	// Normalize: convert to lowercase
@@ -113,40 +144,58 @@ func NormalizeAndValidate(input string) (string, error) {
 
 	// Check for trailing dot
 	if strings.HasSuffix(normalized, ".") {
-		return "", ErrDomainTrailingDot
+		return nil, ErrDomainTrailingDot
 	}
 
 	// Check total length
 	if len(normalized) > 253 {
-		return "", ErrDomainTooLong
+		return nil, ErrDomainTooLong
 	}
 
 	// Validate each label
 	labels := strings.Split(normalized, ".")
 	for _, label := range labels {
 		if len(label) == 0 {
-			return "", ErrDomainInvalidLabel
+			return nil, ErrDomainInvalidLabel
 		}
 		if len(label) > 63 {
-			return "", ErrDomainLabelTooLong
+			return nil, ErrDomainLabelTooLong
 		}
 
 		// Check that label matches valid hostname pattern
 		if len(label) == 1 {
 			if !singleCharLabel.MatchString(label) {
-				return "", ErrDomainInvalidChars
+				return nil, ErrDomainInvalidChars
 			}
 		} else {
 			if !validHostnameChars.MatchString(label) {
-				return "", ErrDomainInvalidChars
+				return nil, ErrDomainInvalidChars
 			}
 		}
 
 		// Labels cannot start or end with hyphen
 		if strings.HasPrefix(label, "-") || strings.HasSuffix(label, "-") {
-			return "", ErrDomainInvalidLabel
+			return nil, ErrDomainInvalidLabel
 		}
 	}
 
-	return normalized, nil
+	return &Target{Domain: normalized, Port: port}, nil
+}
+
+func splitHostPort(input string) (string, int, error) {
+	if strings.Count(input, ":") != 1 {
+		return "", 0, ErrDomainHasPort
+	}
+
+	parts := strings.SplitN(input, ":", 2)
+	if parts[0] == "" || parts[1] == "" {
+		return "", 0, ErrInvalidPort
+	}
+
+	port, err := strconv.Atoi(parts[1])
+	if err != nil || port < 1 || port > 65535 {
+		return "", 0, ErrInvalidPort
+	}
+
+	return parts[0], port, nil
 }

--- a/internal/domain/domain_test.go
+++ b/internal/domain/domain_test.go
@@ -6,10 +6,10 @@ import (
 
 func TestNormalizeAndValidate(t *testing.T) {
 	tests := []struct {
-		name      string
-		input     string
-		want      string
-		wantErr   error
+		name       string
+		input      string
+		want       string
+		wantErr    error
 		wantAnyErr bool // if true, just check that an error is returned
 	}{
 		// Valid cases
@@ -209,9 +209,9 @@ func TestNormalizeAndValidate(t *testing.T) {
 			wantAnyErr: true,
 		},
 		{
-			name:       "label too long (64 chars)",
-			input:      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.com", // 64 'a's exceeds 63 char limit
-			wantErr:    ErrDomainLabelTooLong,
+			name:    "label too long (64 chars)",
+			input:   "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.com", // 64 'a's exceeds 63 char limit
+			wantErr: ErrDomainLabelTooLong,
 		},
 
 		// Edge cases - length
@@ -260,7 +260,7 @@ func TestNormalizeAndValidate_TooLong(t *testing.T) {
 			longDomain = longDomain[:i+2] + "." + longDomain[i+3:]
 		}
 	}
-	
+
 	// Simpler test: just make a really long string
 	longInput := make([]byte, 260)
 	for i := range longInput {
@@ -269,9 +269,74 @@ func TestNormalizeAndValidate_TooLong(t *testing.T) {
 			longInput[i] = '.'
 		}
 	}
-	
+
 	_, err := NormalizeAndValidate(string(longInput))
 	if err != ErrDomainTooLong {
 		t.Errorf("Expected ErrDomainTooLong, got %v", err)
+	}
+}
+
+func TestNormalizeAndValidateTargetWithPort(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    *Target
+		wantErr error
+	}{
+		{
+			name:  "default port",
+			input: "Example.COM",
+			want:  &Target{Domain: "example.com", Port: 443},
+		},
+		{
+			name:  "custom port",
+			input: "Example.COM:8443",
+			want:  &Target{Domain: "example.com", Port: 8443},
+		},
+		{
+			name:  "lowest valid port",
+			input: "example.com:1",
+			want:  &Target{Domain: "example.com", Port: 1},
+		},
+		{
+			name:  "highest valid port",
+			input: "example.com:65535",
+			want:  &Target{Domain: "example.com", Port: 65535},
+		},
+		{
+			name:    "zero port",
+			input:   "example.com:0",
+			wantErr: ErrInvalidPort,
+		},
+		{
+			name:    "too high port",
+			input:   "example.com:65536",
+			wantErr: ErrInvalidPort,
+		},
+		{
+			name:    "non numeric port",
+			input:   "example.com:https",
+			wantErr: ErrInvalidPort,
+		},
+		{
+			name:    "ipv6 literal remains invalid",
+			input:   "::1",
+			wantErr: ErrDomainHasPort,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NormalizeAndValidateTarget(tt.input, true)
+			if err != tt.wantErr {
+				t.Fatalf("NormalizeAndValidateTarget(%q) error = %v, want %v", tt.input, err, tt.wantErr)
+			}
+			if tt.wantErr != nil {
+				return
+			}
+			if got.Domain != tt.want.Domain || got.Port != tt.want.Port {
+				t.Fatalf("NormalizeAndValidateTarget(%q) = %+v, want %+v", tt.input, got, tt.want)
+			}
+		})
 	}
 }

--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -22,13 +22,15 @@ type IndexData struct {
 	Results    *ResultsViewData
 	Error      *ErrorData
 	ManualMode bool
+	PortMode   bool
 }
 
 // handleIndex serves the main page (GET only, read-only, never triggers crawl).
 func (s *Server) handleIndex(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	_, manualMode := r.URL.Query()["manual"]
-	if err := s.templates.ExecuteTemplate(w, "index.html", &IndexData{ManualMode: manualMode}); err != nil {
+	portMode := r.URL.Query().Has("port")
+	if err := s.templates.ExecuteTemplate(w, "index.html", &IndexData{ManualMode: manualMode, PortMode: portMode}); err != nil {
 		s.logger.Error("failed to render index", "error", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 	}
@@ -625,7 +627,7 @@ func formatDomainError(err error) string {
 	case domain.ErrDomainHasScheme:
 		return "Please enter just the domain name without http:// or https://."
 	case domain.ErrDomainHasPort:
-		return "Please enter just the domain name without a port number, or use ?port to enable host:port input."
+		return "Please enter just the domain name without a port number."
 	case domain.ErrInvalidPort:
 		return "Port must be a number between 1 and 65535."
 	case domain.ErrDomainHasPath:

--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -190,11 +190,13 @@ func (s *Server) handleInspect(w http.ResponseWriter, r *http.Request) {
 	}
 
 	rawDomain := r.FormValue("domain")
-	normalizedDomain, err := domain.NormalizeAndValidate(rawDomain)
+	target, err := domain.NormalizeAndValidateTarget(rawDomain, r.URL.Query().Has("port"))
 	if err != nil {
 		s.renderError(w, r, "Invalid Domain", formatDomainError(err), http.StatusBadRequest)
 		return
 	}
+	normalizedDomain := target.Domain
+	port := target.Port
 
 	// Parse filter options
 	filters := parseChainGraphFilters(r)
@@ -212,13 +214,13 @@ func (s *Server) handleInspect(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Check if we need to crawl or can use cached data
-	canRefresh, _, err := s.repo.CanStandardRefresh(r.Context(), normalizedDomain, s.config.StandardRefreshWindow)
+	canRefresh, _, err := s.repo.CanStandardRefreshForPort(r.Context(), normalizedDomain, port, s.config.StandardRefreshWindow)
 	if err != nil {
 		s.logger.Error("failed to check refresh eligibility", "domain", normalizedDomain, "error", err)
 	}
 
 	// Try to get existing data first
-	domainResult, err := s.repo.GetDomainWithChain(r.Context(), normalizedDomain)
+	domainResult, err := s.repo.GetDomainWithChainForPort(r.Context(), normalizedDomain, port)
 
 	if err == nil && domainResult != nil && domainResult.HasChain && !canRefresh {
 		// Use cached data
@@ -227,7 +229,7 @@ func (s *Server) handleInspect(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Need to crawl
-	result, crawlErr := s.performCrawl(r.Context(), normalizedDomain, false)
+	result, crawlErr := s.performCrawl(r.Context(), normalizedDomain, port, false)
 	if crawlErr != nil {
 		s.logger.Warn("crawl failed", "domain", normalizedDomain, "error", crawlErr)
 
@@ -253,11 +255,13 @@ func (s *Server) handleRefresh(w http.ResponseWriter, r *http.Request) {
 	}
 
 	rawDomain := r.FormValue("domain")
-	normalizedDomain, err := domain.NormalizeAndValidate(rawDomain)
+	target, err := domain.NormalizeAndValidateTarget(rawDomain, r.URL.Query().Has("port"))
 	if err != nil {
 		s.renderError(w, r, "Invalid Domain", formatDomainError(err), http.StatusBadRequest)
 		return
 	}
+	normalizedDomain := target.Domain
+	port := target.Port
 
 	// Use default filters for refresh (show everything)
 	// Note: Force refresh intentionally shows all certificates to give users
@@ -269,7 +273,7 @@ func (s *Server) handleRefresh(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Check if forced refresh is allowed
-	canForce, waitTime, err := s.repo.CanForcedRefresh(r.Context(), normalizedDomain, s.config.ForcedRefreshWindow)
+	canForce, waitTime, err := s.repo.CanForcedRefreshForPort(r.Context(), normalizedDomain, port, s.config.ForcedRefreshWindow)
 	if err != nil {
 		s.logger.Error("failed to check forced refresh eligibility", "domain", normalizedDomain, "error", err)
 		s.renderError(w, r, "Error", "Could not verify refresh eligibility.", http.StatusInternalServerError)
@@ -282,12 +286,12 @@ func (s *Server) handleRefresh(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Perform forced crawl
-	result, crawlErr := s.performCrawl(r.Context(), normalizedDomain, true)
+	result, crawlErr := s.performCrawl(r.Context(), normalizedDomain, port, true)
 	if crawlErr != nil {
 		s.logger.Warn("forced crawl failed", "domain", normalizedDomain, "error", crawlErr)
 
 		// Try to get cached data
-		domainResult, _ := s.repo.GetDomainWithChain(r.Context(), normalizedDomain)
+		domainResult, _ := s.repo.GetDomainWithChainForPort(r.Context(), normalizedDomain, port)
 		if domainResult != nil && domainResult.HasChain {
 			s.renderCachedResultsWithError(w, r, domainResult, crawlErr, filters)
 			return
@@ -331,12 +335,12 @@ func (s *Server) handleCertDetails(w http.ResponseWriter, r *http.Request) {
 }
 
 // performCrawl executes a crawl with locking.
-func (s *Server) performCrawl(ctx context.Context, domainName string, forced bool) (*CrawlOutput, error) {
+func (s *Server) performCrawl(ctx context.Context, domainName string, port int, forced bool) (*CrawlOutput, error) {
 	lockID := generateLockID()
 	lockTTL := s.config.CrawlTimeout + 10*time.Second
 
 	// Try to acquire lock
-	acquired, err := s.repo.AcquireLock(ctx, domainName, lockID, lockTTL)
+	acquired, err := s.repo.AcquireLockForPort(ctx, domainName, port, lockID, lockTTL)
 	if err != nil {
 		return nil, fmt.Errorf("failed to acquire lock: %w", err)
 	}
@@ -344,11 +348,12 @@ func (s *Server) performCrawl(ctx context.Context, domainName string, forced boo
 	if !acquired {
 		// Another crawl is in progress, wait a bit and try to get cached results
 		time.Sleep(2 * time.Second)
-		domainResult, err := s.repo.GetDomainWithChain(ctx, domainName)
+		domainResult, err := s.repo.GetDomainWithChainForPort(ctx, domainName, port)
 		if err == nil && domainResult != nil && domainResult.HasChain {
 			// Return the cached data as if it was a fresh crawl
 			return &CrawlOutput{
 				Domain: domainName,
+				Port:   port,
 				Chain:  domainResult.Chain,
 			}, nil
 		}
@@ -357,7 +362,7 @@ func (s *Server) performCrawl(ctx context.Context, domainName string, forced boo
 
 	// Ensure lock is released
 	defer func() {
-		if err := s.repo.ReleaseLock(ctx, domainName, lockID); err != nil {
+		if err := s.repo.ReleaseLockForPort(ctx, domainName, port, lockID); err != nil {
 			s.logger.Warn("failed to release lock", "domain", domainName, "error", err)
 		}
 	}()
@@ -367,11 +372,12 @@ func (s *Server) performCrawl(ctx context.Context, domainName string, forced boo
 	defer cancel()
 
 	// Perform crawl
-	result, err := s.crawler.Crawl(crawlCtx, domainName)
+	result, err := s.crawler.CrawlPort(crawlCtx, domainName, port)
 	if err != nil {
 		// Record failure
 		s.repo.RecordCrawlResult(ctx, &CrawlResultInput{
 			Domain:  domainName,
+			Port:    port,
 			Success: false,
 			Forced:  forced,
 		})
@@ -381,6 +387,7 @@ func (s *Server) performCrawl(ctx context.Context, domainName string, forced boo
 	// Record success
 	if err := s.repo.RecordCrawlResult(ctx, &CrawlResultInput{
 		Domain:  domainName,
+		Port:    port,
 		Success: true,
 		Forced:  forced,
 		Chain:   result.Chain,
@@ -486,13 +493,13 @@ func (s *Server) renderManualError(w http.ResponseWriter, r *http.Request, title
 	}
 }
 func (s *Server) renderCachedResults(w http.ResponseWriter, r *http.Request, result *DomainResult, lastCrawlFailed bool, filters ChainGraphFilters) {
-	canForce, waitTime, _ := s.repo.CanForcedRefresh(r.Context(), result.Domain, s.config.ForcedRefreshWindow)
+	canForce, waitTime, _ := s.repo.CanForcedRefreshForPort(r.Context(), result.Domain, result.Port, s.config.ForcedRefreshWindow)
 
 	data := buildResultsViewData(result, true, canForce, waitTime, lastCrawlFailed)
 
 	// Build the chain graph from the chain certificates
 	data.ChainGraph = buildChainGraph(r.Context(), s.repo, result.Chain, filters)
-	data.DownloadURL = buildNormalDownloadURL(result.Domain, filters)
+	data.DownloadURL = buildNormalDownloadURL(result.Domain, result.Port, filters)
 
 	s.renderResults(w, r, data)
 }
@@ -507,18 +514,19 @@ func (s *Server) renderFreshResults(w http.ResponseWriter, r *http.Request, resu
 	// Convert crawl output to domain result format
 	domainResult := &DomainResult{
 		Domain:    result.Domain,
+		Port:      result.Port,
 		HasChain:  len(result.Chain) > 0,
 		Chain:     result.Chain,
 		UpdatedAt: time.Now(),
 	}
 
-	canForce, waitTime, _ := s.repo.CanForcedRefresh(r.Context(), result.Domain, s.config.ForcedRefreshWindow)
+	canForce, waitTime, _ := s.repo.CanForcedRefreshForPort(r.Context(), result.Domain, result.Port, s.config.ForcedRefreshWindow)
 
 	data := buildResultsViewData(domainResult, false, canForce, waitTime, false)
 
 	// Build the chain graph from the chain certificates
 	data.ChainGraph = buildChainGraph(r.Context(), s.repo, result.Chain, filters)
-	data.DownloadURL = buildNormalDownloadURL(result.Domain, filters)
+	data.DownloadURL = buildNormalDownloadURL(result.Domain, result.Port, filters)
 
 	s.renderResults(w, r, data)
 }
@@ -617,7 +625,9 @@ func formatDomainError(err error) string {
 	case domain.ErrDomainHasScheme:
 		return "Please enter just the domain name without http:// or https://."
 	case domain.ErrDomainHasPort:
-		return "Please enter just the domain name without a port number."
+		return "Please enter just the domain name without a port number, or use ?port to enable host:port input."
+	case domain.ErrInvalidPort:
+		return "Port must be a number between 1 and 65535."
 	case domain.ErrDomainHasPath:
 		return "Please enter just the domain name without any path."
 	case domain.ErrDomainHasQuery:
@@ -635,7 +645,7 @@ func formatCrawlError(err error) string {
 		return "Connection failed. The server may be unreachable."
 	}
 	if strings.Contains(errStr, "tls handshake") {
-		return "TLS handshake failed. The server may not support TLS on port 443."
+		return "TLS handshake failed. The server may not support TLS on the requested port."
 	}
 	if strings.Contains(errStr, "no certificates") {
 		return "No certificates were returned by the server."
@@ -661,9 +671,12 @@ func formatDuration(d time.Duration) string {
 }
 
 // buildNormalDownloadURL constructs the server-side download URL for a domain.
-func buildNormalDownloadURL(domainName string, filters ChainGraphFilters) string {
+func buildNormalDownloadURL(domainName string, port int, filters ChainGraphFilters) string {
 	params := url.Values{}
 	params.Set("domain", domainName)
+	if port != 0 && port != 443 {
+		params.Set("port", fmt.Sprintf("%d", port))
+	}
 	if filters.ShowNonChainCerts {
 		params.Set("showNonChainCerts", "true")
 	}
@@ -710,12 +723,19 @@ func (s *Server) handleDownload(w http.ResponseWriter, r *http.Request) {
 	var filenameBase string
 
 	if domainParam != "" {
-		normalizedDomain, err := domain.NormalizeAndValidate(domainParam)
+		target, err := domain.NormalizeAndValidateTarget(domainParam, false)
 		if err != nil {
 			http.Error(w, "Invalid domain", http.StatusBadRequest)
 			return
 		}
-		domainResult, err := s.repo.GetDomainWithChain(r.Context(), normalizedDomain)
+		if portParam := r.URL.Query().Get("port"); portParam != "" {
+			target, err = domain.NormalizeAndValidateTarget(domainParam+":"+portParam, true)
+			if err != nil {
+				http.Error(w, "Invalid port", http.StatusBadRequest)
+				return
+			}
+		}
+		domainResult, err := s.repo.GetDomainWithChainForPort(r.Context(), target.Domain, target.Port)
 		if err != nil || domainResult == nil || !domainResult.HasChain {
 			http.Error(w, "Domain not found", http.StatusNotFound)
 			return
@@ -725,7 +745,7 @@ func (s *Server) handleDownload(w http.ResponseWriter, r *http.Request) {
 			ShowNonChainCerts: r.URL.Query().Get("showNonChainCerts") == "true",
 			ShowExpired:       r.URL.Query().Get("showExpired") == "true",
 		}
-		filenameBase = normalizedDomain
+		filenameBase = formatTarget(target.Domain, target.Port)
 	} else if certHashHex != "" {
 		hash, err := hex.DecodeString(certHashHex)
 		if err != nil || len(hash) != 32 {
@@ -779,6 +799,6 @@ func (s *Server) handleDownload(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/x-pem-file")
 	// sanitizeDownloadFilename strips all characters that could break the quoted filename
 	// parameter; the explicit quote escaping here adds a defense-in-depth layer.
-	w.Header().Set("Content-Disposition", `attachment; filename="`+strings.ReplaceAll(filename, `"`, `\"`)+ `"`)
+	w.Header().Set("Content-Disposition", `attachment; filename="`+strings.ReplaceAll(filename, `"`, `\"`)+`"`)
 	fmt.Fprint(w, buf.String())
 }

--- a/internal/web/handlers_test.go
+++ b/internal/web/handlers_test.go
@@ -167,6 +167,33 @@ func TestHandleIndex(t *testing.T) {
 	}
 }
 
+func TestHandleIndex_PortModePreservesInspectQuery(t *testing.T) {
+	repo := &mockRepository{}
+	crawler := &mockCrawler{}
+
+	server, err := New(DefaultConfig(), repo, crawler)
+	if err != nil {
+		t.Fatalf("Failed to create server: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/?port", nil)
+	w := httptest.NewRecorder()
+
+	server.handleIndex(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected status 200, got %d", w.Code)
+	}
+
+	body := w.Body.String()
+	if !strings.Contains(body, `action="/inspect?port"`) {
+		t.Errorf("expected inspect form action to preserve port mode, got: %s", body)
+	}
+	if !strings.Contains(body, `hx-post="/inspect?port"`) {
+		t.Errorf("expected HTMX post target to preserve port mode, got: %s", body)
+	}
+}
+
 func TestHandleInspect_ValidDomain(t *testing.T) {
 	repo := &mockRepository{
 		canStandard:  true,
@@ -193,6 +220,40 @@ func TestHandleInspect_ValidDomain(t *testing.T) {
 
 	if w.Code != http.StatusOK {
 		t.Errorf("Expected status 200, got %d", w.Code)
+	}
+}
+
+func TestHandleInspect_ValidDomainWithPortMode(t *testing.T) {
+	repo := &mockRepository{
+		canStandard:  true,
+		canForced:    true,
+		lockAcquired: true,
+	}
+	crawler := &mockCrawler{}
+
+	server, err := New(DefaultConfig(), repo, crawler)
+	if err != nil {
+		t.Fatalf("Failed to create server: %v", err)
+	}
+
+	form := url.Values{}
+	form.Set("domain", "smtp.gmail.com:465")
+
+	req := httptest.NewRequest(http.MethodPost, "/inspect?port", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Host = "localhost:8080"
+
+	w := httptest.NewRecorder()
+	server.handleInspect(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected status 200, got %d", w.Code)
+	}
+	if len(repo.crawlResults) != 1 {
+		t.Fatalf("expected one crawl result, got %d", len(repo.crawlResults))
+	}
+	if repo.crawlResults[0].Domain != "smtp.gmail.com" || repo.crawlResults[0].Port != 465 {
+		t.Fatalf("expected crawl result for smtp.gmail.com:465, got %s:%d", repo.crawlResults[0].Domain, repo.crawlResults[0].Port)
 	}
 }
 
@@ -233,6 +294,9 @@ func TestHandleInspect_InvalidDomain(t *testing.T) {
 			body := w.Body.String()
 			if !strings.Contains(strings.ToLower(body), strings.ToLower(tt.wantErr)) {
 				t.Errorf("Expected error containing %q, got: %s", tt.wantErr, body)
+			}
+			if tt.name == "domain with port" && strings.Contains(body, "?port") {
+				t.Errorf("port-mode error should not disclose hidden query parameter, got: %s", body)
 			}
 		})
 	}

--- a/internal/web/handlers_test.go
+++ b/internal/web/handlers_test.go
@@ -33,10 +33,14 @@ type mockRepository struct {
 }
 
 func (m *mockRepository) GetDomainWithChain(ctx context.Context, domain string) (*DomainResult, error) {
+	return m.GetDomainWithChainForPort(ctx, domain, 443)
+}
+
+func (m *mockRepository) GetDomainWithChainForPort(ctx context.Context, domain string, port int) (*DomainResult, error) {
 	if m.domainResult != nil && m.domainResult.Domain == domain {
 		return m.domainResult, nil
 	}
-	return &DomainResult{Domain: domain}, nil
+	return &DomainResult{Domain: domain, Port: port}, nil
 }
 
 func (m *mockRepository) GetCertificateByHash(ctx context.Context, hash []byte) (*CertificateResult, error) {
@@ -51,18 +55,34 @@ func (m *mockRepository) FindCertificatesBySKI(ctx context.Context, ski []byte) 
 }
 
 func (m *mockRepository) CanStandardRefresh(ctx context.Context, domain string, window time.Duration) (bool, time.Duration, error) {
+	return m.CanStandardRefreshForPort(ctx, domain, 443, window)
+}
+
+func (m *mockRepository) CanStandardRefreshForPort(ctx context.Context, domain string, port int, window time.Duration) (bool, time.Duration, error) {
 	return m.canStandard, m.standardWait, nil
 }
 
 func (m *mockRepository) CanForcedRefresh(ctx context.Context, domain string, window time.Duration) (bool, time.Duration, error) {
+	return m.CanForcedRefreshForPort(ctx, domain, 443, window)
+}
+
+func (m *mockRepository) CanForcedRefreshForPort(ctx context.Context, domain string, port int, window time.Duration) (bool, time.Duration, error) {
 	return m.canForced, m.forcedWait, nil
 }
 
 func (m *mockRepository) AcquireLock(ctx context.Context, domain string, lockID string, ttl time.Duration) (bool, error) {
+	return m.AcquireLockForPort(ctx, domain, 443, lockID, ttl)
+}
+
+func (m *mockRepository) AcquireLockForPort(ctx context.Context, domain string, port int, lockID string, ttl time.Duration) (bool, error) {
 	return m.lockAcquired, nil
 }
 
 func (m *mockRepository) ReleaseLock(ctx context.Context, domain string, lockID string) error {
+	return m.ReleaseLockForPort(ctx, domain, 443, lockID)
+}
+
+func (m *mockRepository) ReleaseLockForPort(ctx context.Context, domain string, port int, lockID string) error {
 	return nil
 }
 
@@ -82,6 +102,10 @@ type mockCrawler struct {
 }
 
 func (m *mockCrawler) Crawl(ctx context.Context, domain string) (*CrawlOutput, error) {
+	return m.CrawlPort(ctx, domain, 443)
+}
+
+func (m *mockCrawler) CrawlPort(ctx context.Context, domain string, port int) (*CrawlOutput, error) {
 	if m.err != nil {
 		return nil, m.err
 	}
@@ -90,6 +114,7 @@ func (m *mockCrawler) Crawl(ctx context.Context, domain string) (*CrawlOutput, e
 	}
 	return &CrawlOutput{
 		Domain: domain,
+		Port:   port,
 		Chain: []*CertificateResult{
 			{
 				CertHash:  make([]byte, 32),
@@ -512,147 +537,147 @@ func TestHandleInspect_ReservedDomain(t *testing.T) {
 
 // generateTestCA creates a self-signed CA certificate and returns the CA cert and signing key.
 func generateTestCA(t *testing.T) (*x509.Certificate, *ecdsa.PrivateKey) {
-t.Helper()
-caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-if err != nil {
-t.Fatalf("generate CA key: %v", err)
-}
-ski := make([]byte, 20)
-if _, err := rand.Read(ski); err != nil {
-t.Fatalf("generate SKI: %v", err)
-}
-tmpl := &x509.Certificate{
-SerialNumber:          big.NewInt(1),
-Subject:               pkix.Name{CommonName: "Test Root CA"},
-NotBefore:             time.Now().Add(-24 * time.Hour),
-NotAfter:              time.Now().Add(10 * 365 * 24 * time.Hour),
-IsCA:                  true,
-BasicConstraintsValid: true,
-KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
-SubjectKeyId:          ski,
-}
-der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &caKey.PublicKey, caKey)
-if err != nil {
-t.Fatalf("create CA cert: %v", err)
-}
-cert, err := x509.ParseCertificate(der)
-if err != nil {
-t.Fatalf("parse CA cert: %v", err)
-}
-return cert, caKey
+	t.Helper()
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate CA key: %v", err)
+	}
+	ski := make([]byte, 20)
+	if _, err := rand.Read(ski); err != nil {
+		t.Fatalf("generate SKI: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "Test Root CA"},
+		NotBefore:             time.Now().Add(-24 * time.Hour),
+		NotAfter:              time.Now().Add(10 * 365 * 24 * time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		SubjectKeyId:          ski,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &caKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("create CA cert: %v", err)
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatalf("parse CA cert: %v", err)
+	}
+	return cert, caKey
 }
 
 // generateTestLeaf creates a leaf certificate signed by the given CA.
 func generateTestLeaf(t *testing.T, caCert *x509.Certificate, caKey *ecdsa.PrivateKey) *x509.Certificate {
-t.Helper()
-leafKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-if err != nil {
-t.Fatalf("generate leaf key: %v", err)
-}
-tmpl := &x509.Certificate{
-SerialNumber:          big.NewInt(2),
-Subject:               pkix.Name{CommonName: "test.example.com"},
-NotBefore:             time.Now().Add(-24 * time.Hour),
-NotAfter:              time.Now().Add(365 * 24 * time.Hour),
-KeyUsage:              x509.KeyUsageDigitalSignature,
-BasicConstraintsValid: true,
-AuthorityKeyId:        caCert.SubjectKeyId,
-}
-der, err := x509.CreateCertificate(rand.Reader, tmpl, caCert, &leafKey.PublicKey, caKey)
-if err != nil {
-t.Fatalf("create leaf cert: %v", err)
-}
-cert, err := x509.ParseCertificate(der)
-if err != nil {
-t.Fatalf("parse leaf cert: %v", err)
-}
-return cert
+	t.Helper()
+	leafKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate leaf key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(2),
+		Subject:               pkix.Name{CommonName: "test.example.com"},
+		NotBefore:             time.Now().Add(-24 * time.Hour),
+		NotAfter:              time.Now().Add(365 * 24 * time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+		AuthorityKeyId:        caCert.SubjectKeyId,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, caCert, &leafKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("create leaf cert: %v", err)
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatalf("parse leaf cert: %v", err)
+	}
+	return cert
 }
 
 // pemEncodeTest encodes a DER certificate as PEM for testing.
 func pemEncodeTest(der []byte) string {
-return string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}))
+	return string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}))
 }
 
 func TestHandleManualCert_EmptyPEM(t *testing.T) {
-repo := &mockRepository{}
-crawler := &mockCrawler{}
-server, err := New(DefaultConfig(), repo, crawler)
-if err != nil {
-t.Fatalf("create server: %v", err)
-}
+	repo := &mockRepository{}
+	crawler := &mockCrawler{}
+	server, err := New(DefaultConfig(), repo, crawler)
+	if err != nil {
+		t.Fatalf("create server: %v", err)
+	}
 
-form := url.Values{}
-form.Set("pem", "")
-req := httptest.NewRequest(http.MethodPost, "/manual", strings.NewReader(form.Encode()))
-req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-req.Header.Set("HX-Request", "true")
-req.Host = "localhost:8080"
+	form := url.Values{}
+	form.Set("pem", "")
+	req := httptest.NewRequest(http.MethodPost, "/manual", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("HX-Request", "true")
+	req.Host = "localhost:8080"
 
-w := httptest.NewRecorder()
-server.handleManualCert(w, req)
+	w := httptest.NewRecorder()
+	server.handleManualCert(w, req)
 
-if w.Code != http.StatusBadRequest {
-t.Errorf("expected 400, got %d", w.Code)
-}
-if !strings.Contains(w.Body.String(), "No Certificate") {
-t.Error("expected 'No Certificate' error")
-}
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "No Certificate") {
+		t.Error("expected 'No Certificate' error")
+	}
 }
 
 func TestHandleManualCert_InvalidPEM(t *testing.T) {
-repo := &mockRepository{}
-crawler := &mockCrawler{}
-server, err := New(DefaultConfig(), repo, crawler)
-if err != nil {
-t.Fatalf("create server: %v", err)
-}
+	repo := &mockRepository{}
+	crawler := &mockCrawler{}
+	server, err := New(DefaultConfig(), repo, crawler)
+	if err != nil {
+		t.Fatalf("create server: %v", err)
+	}
 
-form := url.Values{}
-form.Set("pem", "not a pem certificate")
-req := httptest.NewRequest(http.MethodPost, "/manual", strings.NewReader(form.Encode()))
-req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-req.Header.Set("HX-Request", "true")
-req.Host = "localhost:8080"
+	form := url.Values{}
+	form.Set("pem", "not a pem certificate")
+	req := httptest.NewRequest(http.MethodPost, "/manual", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("HX-Request", "true")
+	req.Host = "localhost:8080"
 
-w := httptest.NewRecorder()
-server.handleManualCert(w, req)
+	w := httptest.NewRecorder()
+	server.handleManualCert(w, req)
 
-if w.Code != http.StatusBadRequest {
-t.Errorf("expected 400, got %d", w.Code)
-}
-if !strings.Contains(w.Body.String(), "Invalid PEM") {
-t.Error("expected 'Invalid PEM' error")
-}
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "Invalid PEM") {
+		t.Error("expected 'Invalid PEM' error")
+	}
 }
 
 func TestHandleManualCert_SelfSigned(t *testing.T) {
-caCert, _ := generateTestCA(t)
+	caCert, _ := generateTestCA(t)
 
-// No cross-signed equivalent in the DB → trust lookup finds nothing → Untrusted.
-repo := &mockRepository{}
-crawler := &mockCrawler{}
-server, err := New(DefaultConfig(), repo, crawler)
-if err != nil {
-t.Fatalf("create server: %v", err)
-}
+	// No cross-signed equivalent in the DB → trust lookup finds nothing → Untrusted.
+	repo := &mockRepository{}
+	crawler := &mockCrawler{}
+	server, err := New(DefaultConfig(), repo, crawler)
+	if err != nil {
+		t.Fatalf("create server: %v", err)
+	}
 
-form := url.Values{}
-form.Set("pem", pemEncodeTest(caCert.Raw))
-req := httptest.NewRequest(http.MethodPost, "/manual", strings.NewReader(form.Encode()))
-req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-req.Header.Set("HX-Request", "true")
-req.Host = "localhost:8080"
+	form := url.Values{}
+	form.Set("pem", pemEncodeTest(caCert.Raw))
+	req := httptest.NewRequest(http.MethodPost, "/manual", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("HX-Request", "true")
+	req.Host = "localhost:8080"
 
-w := httptest.NewRecorder()
-server.handleManualCert(w, req)
+	w := httptest.NewRecorder()
+	server.handleManualCert(w, req)
 
-if w.Code != http.StatusBadRequest {
-t.Errorf("expected 400, got %d", w.Code)
-}
-if !strings.Contains(w.Body.String(), "Untrusted") {
-t.Errorf("expected untrusted error for self-signed cert with no DB match, got: %s", w.Body.String())
-}
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "Untrusted") {
+		t.Errorf("expected untrusted error for self-signed cert with no DB match, got: %s", w.Body.String())
+	}
 }
 
 // generateCrossSignedCA creates two certificates for the same key pair:
@@ -662,269 +687,269 @@ t.Errorf("expected untrusted error for self-signed cert with no DB match, got: %
 // This mirrors real-world cross-signing where a CA key is vouched for by an
 // already-trusted root.
 func generateCrossSignedCA(t *testing.T, trustedParent *x509.Certificate, trustedParentKey *ecdsa.PrivateKey) (selfSigned *x509.Certificate, crossSigned *x509.Certificate) {
-t.Helper()
-// Key for the new CA
-newKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-if err != nil {
-t.Fatalf("generate new CA key: %v", err)
-}
-ski := make([]byte, 20)
-if _, err := rand.Read(ski); err != nil {
-t.Fatalf("generate SKI: %v", err)
-}
+	t.Helper()
+	// Key for the new CA
+	newKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate new CA key: %v", err)
+	}
+	ski := make([]byte, 20)
+	if _, err := rand.Read(ski); err != nil {
+		t.Fatalf("generate SKI: %v", err)
+	}
 
-// Self-signed version (Subject == Issuer)
-selfTmpl := &x509.Certificate{
-SerialNumber:          big.NewInt(10),
-Subject:               pkix.Name{CommonName: "New Cross-Signed Root CA"},
-NotBefore:             time.Now().Add(-24 * time.Hour),
-NotAfter:              time.Now().Add(10 * 365 * 24 * time.Hour),
-IsCA:                  true,
-BasicConstraintsValid: true,
-KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
-SubjectKeyId:          ski,
-}
-selfDER, err := x509.CreateCertificate(rand.Reader, selfTmpl, selfTmpl, &newKey.PublicKey, newKey)
-if err != nil {
-t.Fatalf("create self-signed cert: %v", err)
-}
-selfSigned, err = x509.ParseCertificate(selfDER)
-if err != nil {
-t.Fatalf("parse self-signed cert: %v", err)
-}
+	// Self-signed version (Subject == Issuer)
+	selfTmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(10),
+		Subject:               pkix.Name{CommonName: "New Cross-Signed Root CA"},
+		NotBefore:             time.Now().Add(-24 * time.Hour),
+		NotAfter:              time.Now().Add(10 * 365 * 24 * time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		SubjectKeyId:          ski,
+	}
+	selfDER, err := x509.CreateCertificate(rand.Reader, selfTmpl, selfTmpl, &newKey.PublicKey, newKey)
+	if err != nil {
+		t.Fatalf("create self-signed cert: %v", err)
+	}
+	selfSigned, err = x509.ParseCertificate(selfDER)
+	if err != nil {
+		t.Fatalf("parse self-signed cert: %v", err)
+	}
 
-// Cross-signed version (same key/subject, but issued and signed by trustedParent)
-crossTmpl := &x509.Certificate{
-SerialNumber:          big.NewInt(11),
-Subject:               pkix.Name{CommonName: "New Cross-Signed Root CA"},
-NotBefore:             time.Now().Add(-24 * time.Hour),
-NotAfter:              time.Now().Add(10 * 365 * 24 * time.Hour),
-IsCA:                  true,
-BasicConstraintsValid: true,
-KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
-SubjectKeyId:          ski,
-AuthorityKeyId:        trustedParent.SubjectKeyId,
-}
-crossDER, err := x509.CreateCertificate(rand.Reader, crossTmpl, trustedParent, &newKey.PublicKey, trustedParentKey)
-if err != nil {
-t.Fatalf("create cross-signed cert: %v", err)
-}
-crossSigned, err = x509.ParseCertificate(crossDER)
-if err != nil {
-t.Fatalf("parse cross-signed cert: %v", err)
-}
+	// Cross-signed version (same key/subject, but issued and signed by trustedParent)
+	crossTmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(11),
+		Subject:               pkix.Name{CommonName: "New Cross-Signed Root CA"},
+		NotBefore:             time.Now().Add(-24 * time.Hour),
+		NotAfter:              time.Now().Add(10 * 365 * 24 * time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		SubjectKeyId:          ski,
+		AuthorityKeyId:        trustedParent.SubjectKeyId,
+	}
+	crossDER, err := x509.CreateCertificate(rand.Reader, crossTmpl, trustedParent, &newKey.PublicKey, trustedParentKey)
+	if err != nil {
+		t.Fatalf("create cross-signed cert: %v", err)
+	}
+	crossSigned, err = x509.ParseCertificate(crossDER)
+	if err != nil {
+		t.Fatalf("parse cross-signed cert: %v", err)
+	}
 
-return selfSigned, crossSigned
+	return selfSigned, crossSigned
 }
 
 func TestHandleManualCert_CrossSignedSelfSigned(t *testing.T) {
-// Build a trusted root and a new CA whose key is cross-signed by that root.
-trustedRoot, trustedKey := generateTestCA(t)
-selfSignedNewCA, crossSignedNewCA := generateCrossSignedCA(t, trustedRoot, trustedKey)
+	// Build a trusted root and a new CA whose key is cross-signed by that root.
+	trustedRoot, trustedKey := generateTestCA(t)
+	selfSignedNewCA, crossSignedNewCA := generateCrossSignedCA(t, trustedRoot, trustedKey)
 
-// The DB contains the cross-signed version of the new CA (same SKI as the self-signed version).
-crossInfo := certutil.ParseX509Certificate(crossSignedNewCA)
-crossCand := &CertificateResult{
-CertHash:  crossInfo.CertHash,
-DER:       crossInfo.DER,
-PEM:       crossInfo.PEM(),
-Subject:   crossInfo.Subject,
-Issuer:    crossInfo.Issuer,
-NotBefore: crossInfo.NotBefore,
-NotAfter:  crossInfo.NotAfter,
-SKI:       crossInfo.SKI,
-AKI:       crossInfo.AKI,
-Parsed:    crossInfo.Parsed,
-}
+	// The DB contains the cross-signed version of the new CA (same SKI as the self-signed version).
+	crossInfo := certutil.ParseX509Certificate(crossSignedNewCA)
+	crossCand := &CertificateResult{
+		CertHash:  crossInfo.CertHash,
+		DER:       crossInfo.DER,
+		PEM:       crossInfo.PEM(),
+		Subject:   crossInfo.Subject,
+		Issuer:    crossInfo.Issuer,
+		NotBefore: crossInfo.NotBefore,
+		NotAfter:  crossInfo.NotAfter,
+		SKI:       crossInfo.SKI,
+		AKI:       crossInfo.AKI,
+		Parsed:    crossInfo.Parsed,
+	}
 
-repo := &mockRepository{skiCertificates: []*CertificateResult{crossCand}}
-crawler := &mockCrawler{}
-server, err := New(DefaultConfig(), repo, crawler)
-if err != nil {
-t.Fatalf("create server: %v", err)
-}
+	repo := &mockRepository{skiCertificates: []*CertificateResult{crossCand}}
+	crawler := &mockCrawler{}
+	server, err := New(DefaultConfig(), repo, crawler)
+	if err != nil {
+		t.Fatalf("create server: %v", err)
+	}
 
-// Upload the self-signed version — should be accepted because the cross-signed
-// version (same public key) is already trusted in the DB.
-form := url.Values{}
-form.Set("pem", pemEncodeTest(selfSignedNewCA.Raw))
-req := httptest.NewRequest(http.MethodPost, "/manual", strings.NewReader(form.Encode()))
-req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-req.Header.Set("HX-Request", "true")
-req.Host = "localhost:8080"
+	// Upload the self-signed version — should be accepted because the cross-signed
+	// version (same public key) is already trusted in the DB.
+	form := url.Values{}
+	form.Set("pem", pemEncodeTest(selfSignedNewCA.Raw))
+	req := httptest.NewRequest(http.MethodPost, "/manual", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("HX-Request", "true")
+	req.Host = "localhost:8080"
 
-w := httptest.NewRecorder()
-server.handleManualCert(w, req)
+	w := httptest.NewRecorder()
+	server.handleManualCert(w, req)
 
-if w.Code != http.StatusOK {
-t.Errorf("expected 200 for cross-signed self-signed cert, got %d: %s", w.Code, w.Body.String())
-}
-if !strings.Contains(w.Body.String(), "manual import") {
-t.Errorf("expected 'manual import' status chip in results, got: %s", w.Body.String())
-}
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 for cross-signed self-signed cert, got %d: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "manual import") {
+		t.Errorf("expected 'manual import' status chip in results, got: %s", w.Body.String())
+	}
 }
 
 func TestHandleManualCert_UntrustedCert(t *testing.T) {
-caCert, caKey := generateTestCA(t)
-leafCert := generateTestLeaf(t, caCert, caKey)
+	caCert, caKey := generateTestCA(t)
+	leafCert := generateTestLeaf(t, caCert, caKey)
 
-// repo has no matching SKI candidates → untrusted
-repo := &mockRepository{skiCertificates: nil}
-crawler := &mockCrawler{}
-server, err := New(DefaultConfig(), repo, crawler)
-if err != nil {
-t.Fatalf("create server: %v", err)
-}
+	// repo has no matching SKI candidates → untrusted
+	repo := &mockRepository{skiCertificates: nil}
+	crawler := &mockCrawler{}
+	server, err := New(DefaultConfig(), repo, crawler)
+	if err != nil {
+		t.Fatalf("create server: %v", err)
+	}
 
-form := url.Values{}
-form.Set("pem", pemEncodeTest(leafCert.Raw))
-req := httptest.NewRequest(http.MethodPost, "/manual", strings.NewReader(form.Encode()))
-req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-req.Header.Set("HX-Request", "true")
-req.Host = "localhost:8080"
+	form := url.Values{}
+	form.Set("pem", pemEncodeTest(leafCert.Raw))
+	req := httptest.NewRequest(http.MethodPost, "/manual", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("HX-Request", "true")
+	req.Host = "localhost:8080"
 
-w := httptest.NewRecorder()
-server.handleManualCert(w, req)
+	w := httptest.NewRecorder()
+	server.handleManualCert(w, req)
 
-if w.Code != http.StatusBadRequest {
-t.Errorf("expected 400, got %d", w.Code)
-}
-if !strings.Contains(w.Body.String(), "Untrusted") {
-t.Error("expected untrusted error")
-}
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "Untrusted") {
+		t.Error("expected untrusted error")
+	}
 }
 
 func TestHandleManualCert_ValidCert(t *testing.T) {
-caCert, caKey := generateTestCA(t)
-leafCert := generateTestLeaf(t, caCert, caKey)
+	caCert, caKey := generateTestCA(t)
+	leafCert := generateTestLeaf(t, caCert, caKey)
 
-// Provide the CA cert as a trusted SKI candidate
-caInfo := certutil.ParseX509Certificate(caCert)
-skiCand := &CertificateResult{
-CertHash:  caInfo.CertHash,
-DER:       caInfo.DER,
-PEM:       caInfo.PEM(),
-Subject:   caInfo.Subject,
-Issuer:    caInfo.Issuer,
-NotBefore: caInfo.NotBefore,
-NotAfter:  caInfo.NotAfter,
-SKI:       caInfo.SKI,
-AKI:       caInfo.AKI,
-Parsed:    caInfo.Parsed,
-}
+	// Provide the CA cert as a trusted SKI candidate
+	caInfo := certutil.ParseX509Certificate(caCert)
+	skiCand := &CertificateResult{
+		CertHash:  caInfo.CertHash,
+		DER:       caInfo.DER,
+		PEM:       caInfo.PEM(),
+		Subject:   caInfo.Subject,
+		Issuer:    caInfo.Issuer,
+		NotBefore: caInfo.NotBefore,
+		NotAfter:  caInfo.NotAfter,
+		SKI:       caInfo.SKI,
+		AKI:       caInfo.AKI,
+		Parsed:    caInfo.Parsed,
+	}
 
-repo := &mockRepository{skiCertificates: []*CertificateResult{skiCand}}
-crawler := &mockCrawler{}
-server, err := New(DefaultConfig(), repo, crawler)
-if err != nil {
-t.Fatalf("create server: %v", err)
-}
+	repo := &mockRepository{skiCertificates: []*CertificateResult{skiCand}}
+	crawler := &mockCrawler{}
+	server, err := New(DefaultConfig(), repo, crawler)
+	if err != nil {
+		t.Fatalf("create server: %v", err)
+	}
 
-form := url.Values{}
-form.Set("pem", pemEncodeTest(leafCert.Raw))
-req := httptest.NewRequest(http.MethodPost, "/manual", strings.NewReader(form.Encode()))
-req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-req.Header.Set("HX-Request", "true")
-req.Host = "localhost:8080"
+	form := url.Values{}
+	form.Set("pem", pemEncodeTest(leafCert.Raw))
+	req := httptest.NewRequest(http.MethodPost, "/manual", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("HX-Request", "true")
+	req.Host = "localhost:8080"
 
-w := httptest.NewRecorder()
-server.handleManualCert(w, req)
+	w := httptest.NewRecorder()
+	server.handleManualCert(w, req)
 
-if w.Code != http.StatusOK {
-t.Errorf("expected 200, got %d: %s", w.Code, w.Body.String())
-}
-if !strings.Contains(w.Body.String(), "manual import") {
-t.Error("expected 'manual import' status chip in results")
-}
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "manual import") {
+		t.Error("expected 'manual import' status chip in results")
+	}
 }
 
 func TestHandleIndex_ManualMode(t *testing.T) {
-repo := &mockRepository{}
-crawler := &mockCrawler{}
-server, err := New(DefaultConfig(), repo, crawler)
-if err != nil {
-t.Fatalf("create server: %v", err)
-}
+	repo := &mockRepository{}
+	crawler := &mockCrawler{}
+	server, err := New(DefaultConfig(), repo, crawler)
+	if err != nil {
+		t.Fatalf("create server: %v", err)
+	}
 
-req := httptest.NewRequest(http.MethodGet, "/?manual", nil)
-w := httptest.NewRecorder()
-server.handleIndex(w, req)
+	req := httptest.NewRequest(http.MethodGet, "/?manual", nil)
+	w := httptest.NewRecorder()
+	server.handleIndex(w, req)
 
-if w.Code != http.StatusOK {
-t.Errorf("expected 200, got %d", w.Code)
-}
-if !strings.Contains(w.Body.String(), "Import Certificate") {
-t.Error("expected 'Import Certificate' heading in manual mode")
-}
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "Import Certificate") {
+		t.Error("expected 'Import Certificate' heading in manual mode")
+	}
 }
 
 func TestHandleManualCert_NonCertificatePEMBlock(t *testing.T) {
-repo := &mockRepository{}
-crawler := &mockCrawler{}
-server, err := New(DefaultConfig(), repo, crawler)
-if err != nil {
-t.Fatalf("create server: %v", err)
-}
+	repo := &mockRepository{}
+	crawler := &mockCrawler{}
+	server, err := New(DefaultConfig(), repo, crawler)
+	if err != nil {
+		t.Fatalf("create server: %v", err)
+	}
 
-// Generate a private key PEM block (not a CERTIFICATE)
-privKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-if err != nil {
-t.Fatalf("generate key: %v", err)
-}
-keyDER, err := x509.MarshalECPrivateKey(privKey)
-if err != nil {
-t.Fatalf("marshal key: %v", err)
-}
-keyPEM := string(pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER}))
+	// Generate a private key PEM block (not a CERTIFICATE)
+	privKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	keyDER, err := x509.MarshalECPrivateKey(privKey)
+	if err != nil {
+		t.Fatalf("marshal key: %v", err)
+	}
+	keyPEM := string(pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER}))
 
-form := url.Values{}
-form.Set("pem", keyPEM)
-req := httptest.NewRequest(http.MethodPost, "/manual", strings.NewReader(form.Encode()))
-req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-req.Header.Set("HX-Request", "true")
-req.Host = "localhost:8080"
+	form := url.Values{}
+	form.Set("pem", keyPEM)
+	req := httptest.NewRequest(http.MethodPost, "/manual", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("HX-Request", "true")
+	req.Host = "localhost:8080"
 
-w := httptest.NewRecorder()
-server.handleManualCert(w, req)
+	w := httptest.NewRecorder()
+	server.handleManualCert(w, req)
 
-if w.Code != http.StatusBadRequest {
-t.Errorf("expected 400, got %d", w.Code)
-}
-if !strings.Contains(w.Body.String(), "Invalid PEM") {
-t.Errorf("expected 'Invalid PEM' error, got: %s", w.Body.String())
-}
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "Invalid PEM") {
+		t.Errorf("expected 'Invalid PEM' error, got: %s", w.Body.String())
+	}
 }
 
 func TestHandleManualCert_MultiplePEMBlocks(t *testing.T) {
-caCert, caKey := generateTestCA(t)
-leafCert := generateTestLeaf(t, caCert, caKey)
+	caCert, caKey := generateTestCA(t)
+	leafCert := generateTestLeaf(t, caCert, caKey)
 
-// Submit two certificates in the PEM field
-twoCerts := pemEncodeTest(leafCert.Raw) + pemEncodeTest(caCert.Raw)
+	// Submit two certificates in the PEM field
+	twoCerts := pemEncodeTest(leafCert.Raw) + pemEncodeTest(caCert.Raw)
 
-repo := &mockRepository{}
-crawler := &mockCrawler{}
-server, err := New(DefaultConfig(), repo, crawler)
-if err != nil {
-t.Fatalf("create server: %v", err)
-}
+	repo := &mockRepository{}
+	crawler := &mockCrawler{}
+	server, err := New(DefaultConfig(), repo, crawler)
+	if err != nil {
+		t.Fatalf("create server: %v", err)
+	}
 
-form := url.Values{}
-form.Set("pem", twoCerts)
-req := httptest.NewRequest(http.MethodPost, "/manual", strings.NewReader(form.Encode()))
-req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-req.Header.Set("HX-Request", "true")
-req.Host = "localhost:8080"
+	form := url.Values{}
+	form.Set("pem", twoCerts)
+	req := httptest.NewRequest(http.MethodPost, "/manual", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("HX-Request", "true")
+	req.Host = "localhost:8080"
 
-w := httptest.NewRecorder()
-server.handleManualCert(w, req)
+	w := httptest.NewRecorder()
+	server.handleManualCert(w, req)
 
-if w.Code != http.StatusBadRequest {
-t.Errorf("expected 400, got %d", w.Code)
-}
-if !strings.Contains(w.Body.String(), "Multiple PEM Blocks") {
-t.Errorf("expected 'Multiple PEM Blocks' error, got: %s", w.Body.String())
-}
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "Multiple PEM Blocks") {
+		t.Errorf("expected 'Multiple PEM Blocks' error, got: %s", w.Body.String())
+	}
 }
 
 func TestHandleManualCert_TrailingPEMBlock(t *testing.T) {
@@ -1003,199 +1028,199 @@ func TestHandleManualCert_TrailingNonPEMJunk(t *testing.T) {
 }
 
 func TestHandleManualCert_MissingAKI(t *testing.T) {
-// Generate a leaf cert signed by a CA but without AKI extension
-caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-if err != nil {
-t.Fatalf("generate CA key: %v", err)
-}
-caTemplate := &x509.Certificate{
-SerialNumber:          big.NewInt(1),
-Subject:               pkix.Name{CommonName: "Test Root CA"},
-NotBefore:             time.Now().Add(-24 * time.Hour),
-NotAfter:              time.Now().Add(10 * 365 * 24 * time.Hour),
-IsCA:                  true,
-BasicConstraintsValid: true,
-KeyUsage:              x509.KeyUsageCertSign,
-SubjectKeyId:          []byte{1, 2, 3, 4, 5},
-}
-caDER, err := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caKey.PublicKey, caKey)
-if err != nil {
-t.Fatalf("create CA: %v", err)
-}
-caCert, _ := x509.ParseCertificate(caDER)
+	// Generate a leaf cert signed by a CA but without AKI extension
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate CA key: %v", err)
+	}
+	caTemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "Test Root CA"},
+		NotBefore:             time.Now().Add(-24 * time.Hour),
+		NotAfter:              time.Now().Add(10 * 365 * 24 * time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign,
+		SubjectKeyId:          []byte{1, 2, 3, 4, 5},
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("create CA: %v", err)
+	}
+	caCert, _ := x509.ParseCertificate(caDER)
 
-leafKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-if err != nil {
-t.Fatalf("generate leaf key: %v", err)
-}
-// Leaf cert has NO AuthorityKeyId
-leafTemplate := &x509.Certificate{
-SerialNumber:          big.NewInt(2),
-Subject:               pkix.Name{CommonName: "no-aki.example.com"},
-NotBefore:             time.Now().Add(-24 * time.Hour),
-NotAfter:              time.Now().Add(365 * 24 * time.Hour),
-KeyUsage:              x509.KeyUsageDigitalSignature,
-BasicConstraintsValid: true,
-// AuthorityKeyId intentionally omitted
-}
-leafDER, err := x509.CreateCertificate(rand.Reader, leafTemplate, caCert, &leafKey.PublicKey, caKey)
-if err != nil {
-t.Fatalf("create leaf: %v", err)
-}
-leafCert, _ := x509.ParseCertificate(leafDER)
+	leafKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate leaf key: %v", err)
+	}
+	// Leaf cert has NO AuthorityKeyId
+	leafTemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(2),
+		Subject:               pkix.Name{CommonName: "no-aki.example.com"},
+		NotBefore:             time.Now().Add(-24 * time.Hour),
+		NotAfter:              time.Now().Add(365 * 24 * time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+		// AuthorityKeyId intentionally omitted
+	}
+	leafDER, err := x509.CreateCertificate(rand.Reader, leafTemplate, caCert, &leafKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("create leaf: %v", err)
+	}
+	leafCert, _ := x509.ParseCertificate(leafDER)
 
-repo := &mockRepository{}
-crawler := &mockCrawler{}
-server, err := New(DefaultConfig(), repo, crawler)
-if err != nil {
-t.Fatalf("create server: %v", err)
-}
+	repo := &mockRepository{}
+	crawler := &mockCrawler{}
+	server, err := New(DefaultConfig(), repo, crawler)
+	if err != nil {
+		t.Fatalf("create server: %v", err)
+	}
 
-form := url.Values{}
-form.Set("pem", pemEncodeTest(leafCert.Raw))
-req := httptest.NewRequest(http.MethodPost, "/manual", strings.NewReader(form.Encode()))
-req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-req.Header.Set("HX-Request", "true")
-req.Host = "localhost:8080"
+	form := url.Values{}
+	form.Set("pem", pemEncodeTest(leafCert.Raw))
+	req := httptest.NewRequest(http.MethodPost, "/manual", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("HX-Request", "true")
+	req.Host = "localhost:8080"
 
-w := httptest.NewRecorder()
-server.handleManualCert(w, req)
+	w := httptest.NewRecorder()
+	server.handleManualCert(w, req)
 
-if w.Code != http.StatusBadRequest {
-t.Errorf("expected 400, got %d", w.Code)
-}
-if !strings.Contains(w.Body.String(), "Untrusted Certificate") {
-t.Errorf("expected 'Untrusted Certificate' error for missing AKI, got: %s", w.Body.String())
-}
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "Untrusted Certificate") {
+		t.Errorf("expected 'Untrusted Certificate' error for missing AKI, got: %s", w.Body.String())
+	}
 }
 
 func TestHandleManualCert_NonCAIssuerRejected(t *testing.T) {
-// A cert signed by a non-CA cert (IsCA=false) should be rejected
-// because CheckSignatureFrom enforces CA status
-nonCAKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-if err != nil {
-t.Fatalf("generate key: %v", err)
-}
-ski := []byte{10, 20, 30, 40, 50}
-// Create a non-CA "signer" cert (IsCA=false)
-nonCATemplate := &x509.Certificate{
-SerialNumber:          big.NewInt(1),
-Subject:               pkix.Name{CommonName: "Not A CA"},
-NotBefore:             time.Now().Add(-24 * time.Hour),
-NotAfter:              time.Now().Add(10 * 365 * 24 * time.Hour),
-IsCA:                  false,
-BasicConstraintsValid: true,
-SubjectKeyId:          ski,
-}
-nonCADER, err := x509.CreateCertificate(rand.Reader, nonCATemplate, nonCATemplate, &nonCAKey.PublicKey, nonCAKey)
-if err != nil {
-t.Fatalf("create non-CA: %v", err)
-}
-nonCACert, _ := x509.ParseCertificate(nonCADER)
+	// A cert signed by a non-CA cert (IsCA=false) should be rejected
+	// because CheckSignatureFrom enforces CA status
+	nonCAKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	ski := []byte{10, 20, 30, 40, 50}
+	// Create a non-CA "signer" cert (IsCA=false)
+	nonCATemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "Not A CA"},
+		NotBefore:             time.Now().Add(-24 * time.Hour),
+		NotAfter:              time.Now().Add(10 * 365 * 24 * time.Hour),
+		IsCA:                  false,
+		BasicConstraintsValid: true,
+		SubjectKeyId:          ski,
+	}
+	nonCADER, err := x509.CreateCertificate(rand.Reader, nonCATemplate, nonCATemplate, &nonCAKey.PublicKey, nonCAKey)
+	if err != nil {
+		t.Fatalf("create non-CA: %v", err)
+	}
+	nonCACert, _ := x509.ParseCertificate(nonCADER)
 
-// Create a leaf signed by the non-CA cert
-leafKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-if err != nil {
-t.Fatalf("generate leaf key: %v", err)
-}
-leafTemplate := &x509.Certificate{
-SerialNumber:          big.NewInt(2),
-Subject:               pkix.Name{CommonName: "leaf.example.com"},
-NotBefore:             time.Now().Add(-24 * time.Hour),
-NotAfter:              time.Now().Add(365 * 24 * time.Hour),
-KeyUsage:              x509.KeyUsageDigitalSignature,
-BasicConstraintsValid: true,
-AuthorityKeyId:        ski,
-}
-leafDER, err := x509.CreateCertificate(rand.Reader, leafTemplate, nonCACert, &leafKey.PublicKey, nonCAKey)
-if err != nil {
-t.Fatalf("create leaf: %v", err)
-}
-leafCert, _ := x509.ParseCertificate(leafDER)
+	// Create a leaf signed by the non-CA cert
+	leafKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate leaf key: %v", err)
+	}
+	leafTemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(2),
+		Subject:               pkix.Name{CommonName: "leaf.example.com"},
+		NotBefore:             time.Now().Add(-24 * time.Hour),
+		NotAfter:              time.Now().Add(365 * 24 * time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+		AuthorityKeyId:        ski,
+	}
+	leafDER, err := x509.CreateCertificate(rand.Reader, leafTemplate, nonCACert, &leafKey.PublicKey, nonCAKey)
+	if err != nil {
+		t.Fatalf("create leaf: %v", err)
+	}
+	leafCert, _ := x509.ParseCertificate(leafDER)
 
-// The non-CA cert is in the DB as a candidate (SKI matches)
-nonCAInfo := certutil.ParseX509Certificate(nonCACert)
-skiCand := &CertificateResult{
-CertHash:  nonCAInfo.CertHash,
-DER:       nonCAInfo.DER,
-PEM:       nonCAInfo.PEM(),
-Subject:   nonCAInfo.Subject,
-Issuer:    nonCAInfo.Issuer,
-NotBefore: nonCAInfo.NotBefore,
-NotAfter:  nonCAInfo.NotAfter,
-SKI:       nonCAInfo.SKI,
-AKI:       nonCAInfo.AKI,
-Parsed:    nonCAInfo.Parsed,
-}
+	// The non-CA cert is in the DB as a candidate (SKI matches)
+	nonCAInfo := certutil.ParseX509Certificate(nonCACert)
+	skiCand := &CertificateResult{
+		CertHash:  nonCAInfo.CertHash,
+		DER:       nonCAInfo.DER,
+		PEM:       nonCAInfo.PEM(),
+		Subject:   nonCAInfo.Subject,
+		Issuer:    nonCAInfo.Issuer,
+		NotBefore: nonCAInfo.NotBefore,
+		NotAfter:  nonCAInfo.NotAfter,
+		SKI:       nonCAInfo.SKI,
+		AKI:       nonCAInfo.AKI,
+		Parsed:    nonCAInfo.Parsed,
+	}
 
-repo := &mockRepository{skiCertificates: []*CertificateResult{skiCand}}
-crawler := &mockCrawler{}
-server, err := New(DefaultConfig(), repo, crawler)
-if err != nil {
-t.Fatalf("create server: %v", err)
-}
+	repo := &mockRepository{skiCertificates: []*CertificateResult{skiCand}}
+	crawler := &mockCrawler{}
+	server, err := New(DefaultConfig(), repo, crawler)
+	if err != nil {
+		t.Fatalf("create server: %v", err)
+	}
 
-form := url.Values{}
-form.Set("pem", pemEncodeTest(leafCert.Raw))
-req := httptest.NewRequest(http.MethodPost, "/manual", strings.NewReader(form.Encode()))
-req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-req.Header.Set("HX-Request", "true")
-req.Host = "localhost:8080"
+	form := url.Values{}
+	form.Set("pem", pemEncodeTest(leafCert.Raw))
+	req := httptest.NewRequest(http.MethodPost, "/manual", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("HX-Request", "true")
+	req.Host = "localhost:8080"
 
-w := httptest.NewRecorder()
-server.handleManualCert(w, req)
+	w := httptest.NewRecorder()
+	server.handleManualCert(w, req)
 
-if w.Code != http.StatusBadRequest {
-t.Errorf("expected 400 for non-CA issuer, got %d: %s", w.Code, w.Body.String())
-}
-if !strings.Contains(w.Body.String(), "Untrusted") {
-t.Errorf("expected untrusted error for non-CA issuer, got: %s", w.Body.String())
-}
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for non-CA issuer, got %d: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "Untrusted") {
+		t.Errorf("expected untrusted error for non-CA issuer, got: %s", w.Body.String())
+	}
 }
 
 func TestHandleManualCert_FullPagePreservesManualMode(t *testing.T) {
-caCert, caKey := generateTestCA(t)
-leafCert := generateTestLeaf(t, caCert, caKey)
+	caCert, caKey := generateTestCA(t)
+	leafCert := generateTestLeaf(t, caCert, caKey)
 
-caInfo := certutil.ParseX509Certificate(caCert)
-skiCand := &CertificateResult{
-CertHash:  caInfo.CertHash,
-DER:       caInfo.DER,
-PEM:       caInfo.PEM(),
-Subject:   caInfo.Subject,
-Issuer:    caInfo.Issuer,
-NotBefore: caInfo.NotBefore,
-NotAfter:  caInfo.NotAfter,
-SKI:       caInfo.SKI,
-AKI:       caInfo.AKI,
-Parsed:    caInfo.Parsed,
-}
+	caInfo := certutil.ParseX509Certificate(caCert)
+	skiCand := &CertificateResult{
+		CertHash:  caInfo.CertHash,
+		DER:       caInfo.DER,
+		PEM:       caInfo.PEM(),
+		Subject:   caInfo.Subject,
+		Issuer:    caInfo.Issuer,
+		NotBefore: caInfo.NotBefore,
+		NotAfter:  caInfo.NotAfter,
+		SKI:       caInfo.SKI,
+		AKI:       caInfo.AKI,
+		Parsed:    caInfo.Parsed,
+	}
 
-repo := &mockRepository{skiCertificates: []*CertificateResult{skiCand}}
-crawler := &mockCrawler{}
-server, err := New(DefaultConfig(), repo, crawler)
-if err != nil {
-t.Fatalf("create server: %v", err)
-}
+	repo := &mockRepository{skiCertificates: []*CertificateResult{skiCand}}
+	crawler := &mockCrawler{}
+	server, err := New(DefaultConfig(), repo, crawler)
+	if err != nil {
+		t.Fatalf("create server: %v", err)
+	}
 
-form := url.Values{}
-form.Set("pem", pemEncodeTest(leafCert.Raw))
-// No HX-Request header → full page response
-req := httptest.NewRequest(http.MethodPost, "/manual", strings.NewReader(form.Encode()))
-req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-req.Host = "localhost:8080"
+	form := url.Values{}
+	form.Set("pem", pemEncodeTest(leafCert.Raw))
+	// No HX-Request header → full page response
+	req := httptest.NewRequest(http.MethodPost, "/manual", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Host = "localhost:8080"
 
-w := httptest.NewRecorder()
-server.handleManualCert(w, req)
+	w := httptest.NewRecorder()
+	server.handleManualCert(w, req)
 
-if w.Code != http.StatusOK {
-t.Errorf("expected 200, got %d: %s", w.Code, w.Body.String())
-}
-// Full page response should show the PEM textarea (manual mode form), not the domain input
-body := w.Body.String()
-if !strings.Contains(body, "Import Certificate") {
-t.Errorf("expected 'Import Certificate' heading (manual mode) in full-page response, got domain form instead")
-}
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	// Full page response should show the PEM textarea (manual mode form), not the domain input
+	body := w.Body.String()
+	if !strings.Contains(body, "Import Certificate") {
+		t.Errorf("expected 'Import Certificate' heading (manual mode) in full-page response, got domain form instead")
+	}
 }
 
 func TestHandleDownload_MissingParams(t *testing.T) {
@@ -1325,7 +1350,7 @@ func TestSanitizeDownloadFilename(t *testing.T) {
 }
 
 func TestBuildNormalDownloadURL(t *testing.T) {
-	url := buildNormalDownloadURL("github.com", ChainGraphFilters{ShowNonChainCerts: true, ShowExpired: false})
+	url := buildNormalDownloadURL("github.com", 443, ChainGraphFilters{ShowNonChainCerts: true, ShowExpired: false})
 	if !strings.Contains(url, "domain=github.com") {
 		t.Errorf("expected domain param in URL, got %s", url)
 	}
@@ -1334,6 +1359,11 @@ func TestBuildNormalDownloadURL(t *testing.T) {
 	}
 	if strings.Contains(url, "showExpired") {
 		t.Errorf("expected no showExpired param when false, got %s", url)
+	}
+
+	url = buildNormalDownloadURL("github.com", 8443, ChainGraphFilters{})
+	if !strings.Contains(url, "port=8443") {
+		t.Errorf("expected port param in URL, got %s", url)
 	}
 }
 

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -66,6 +66,8 @@ type Server struct {
 type Repository interface {
 	// GetDomainWithChain retrieves a domain and its current chain with certificates.
 	GetDomainWithChain(ctx context.Context, domain string) (*DomainResult, error)
+	// GetDomainWithChainForPort retrieves a domain target and its current chain with certificates.
+	GetDomainWithChainForPort(ctx context.Context, domain string, port int) (*DomainResult, error)
 	// GetCertificateByHash retrieves a certificate by its hash.
 	GetCertificateByHash(ctx context.Context, hash []byte) (*CertificateResult, error)
 	// FindCertificatesBySKI finds certificates whose SKI matches the given value.
@@ -73,12 +75,20 @@ type Repository interface {
 	FindCertificatesBySKI(ctx context.Context, ski []byte) ([]*CertificateResult, error)
 	// CanStandardRefresh checks if a standard refresh is allowed for the domain.
 	CanStandardRefresh(ctx context.Context, domain string, window time.Duration) (bool, time.Duration, error)
+	// CanStandardRefreshForPort checks if a standard refresh is allowed for the domain target.
+	CanStandardRefreshForPort(ctx context.Context, domain string, port int, window time.Duration) (bool, time.Duration, error)
 	// CanForcedRefresh checks if a forced refresh is allowed for the domain.
 	CanForcedRefresh(ctx context.Context, domain string, window time.Duration) (bool, time.Duration, error)
+	// CanForcedRefreshForPort checks if a forced refresh is allowed for the domain target.
+	CanForcedRefreshForPort(ctx context.Context, domain string, port int, window time.Duration) (bool, time.Duration, error)
 	// AcquireLock tries to acquire a crawl lock for the domain.
 	AcquireLock(ctx context.Context, domain string, lockID string, ttl time.Duration) (bool, error)
+	// AcquireLockForPort tries to acquire a crawl lock for the domain target.
+	AcquireLockForPort(ctx context.Context, domain string, port int, lockID string, ttl time.Duration) (bool, error)
 	// ReleaseLock releases a crawl lock for the domain.
 	ReleaseLock(ctx context.Context, domain string, lockID string) error
+	// ReleaseLockForPort releases a crawl lock for the domain target.
+	ReleaseLockForPort(ctx context.Context, domain string, port int, lockID string) error
 	// RecordCrawlResult records the result of a crawl operation.
 	RecordCrawlResult(ctx context.Context, result *CrawlResultInput) error
 	// StoreCertificate stores a single certificate in the database.
@@ -89,6 +99,8 @@ type Repository interface {
 type Crawler interface {
 	// Crawl performs a TLS handshake and returns the certificate chain.
 	Crawl(ctx context.Context, domain string) (*CrawlOutput, error)
+	// CrawlPort performs a TLS handshake on the specified port and returns the certificate chain.
+	CrawlPort(ctx context.Context, domain string, port int) (*CrawlOutput, error)
 }
 
 // New creates a new web server.

--- a/internal/web/templates/index.html
+++ b/internal/web/templates/index.html
@@ -58,7 +58,7 @@
                 </div>
                 {{else}}
                 <h2 class="panel-title"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="inline-block align-middle" style="margin-right: 0.5rem;"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M21 12a9 9 0 1 0 -9 9" /><path d="M3.6 9h16.8" /><path d="M3.6 15h8.4" /><path d="M11.578 3a17 17 0 0 0 0 18" /><path d="M12.5 3c1.719 2.755 2.5 5.876 2.5 9" /><path d="M18 14v7m-3 -3l3 3l3 -3" /></svg>Retrieve Certificate</h2>
-                <form id="inspect-form" method="POST" action="/inspect" class="domain-form" hx-post="/inspect" hx-target="#results" hx-indicator="#loading">
+                <form id="inspect-form" method="POST" action="/inspect{{if .PortMode}}?port{{end}}" class="domain-form" hx-post="/inspect{{if .PortMode}}?port{{end}}" hx-target="#results" hx-indicator="#loading">
                     <input
                         type="text"
                         name="domain"

--- a/internal/web/templates/index.html
+++ b/internal/web/templates/index.html
@@ -117,7 +117,7 @@
                     </li>
                     <li class="info-row">
                         <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="mt-0.5 h-[18px] w-[18px]"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M12 3a12 12 0 0 0 8.5 3a12 12 0 0 1 -8.5 15a12 12 0 0 1 -8.5 -15a12 12 0 0 0 8.5 -3" /><path d="M11 11a1 1 0 1 0 2 0a1 1 0 0 0 -2 0" /><path d="M12 12l0 2.5" /></svg>
-                        <span><strong>Basic TLS handshake</strong> on port 443; no HTTP requests, no redirects followed</span>
+                        <span><strong>Basic TLS handshake</strong> on the requested port; no HTTP requests, no redirects followed</span>
                     </li>
                     <li class="info-row">
                         <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="mt-0.5 h-[18px] w-[18px]"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M12 15a3 3 0 1 0 6 0a3 3 0 1 0 -6 0" /><path d="M13 17.5v4.5l2 -1.5l2 1.5v-4.5" /><path d="M10 19h-5a2 2 0 0 1 -2 -2v-10c0 -1.1 .9 -2 2 -2h14a2 2 0 0 1 2 2v10a2 2 0 0 1 -1 1.73" /><path d="M6 9l12 0" /><path d="M6 12l3 0" /><path d="M6 15l2 0" /></svg>

--- a/internal/web/templates/results.html
+++ b/internal/web/templates/results.html
@@ -2,7 +2,7 @@
 <div class="results-wrap">
     <div class="results-toolbar">
         <div class="status-row">
-            <span class="domain-name">{{.Domain}}</span>
+            <span class="domain-name">{{.DisplayTarget}}</span>
             {{if .IsManual}}
             <span class="status-chip status-fresh">manual import</span>
             {{else if .IsCached}}
@@ -15,8 +15,8 @@
             {{end}}
         </div>
         {{if and .CanForceRefresh .IsCached}}
-        <form method="POST" action="/refresh" class="inline" hx-post="/refresh" hx-target="#results" hx-indicator="#loading" hx-on::before-request="clearResults()">
-            <input type="hidden" name="domain" value="{{.Domain}}">
+        <form method="POST" action="/refresh{{if ne .Port 443}}?port{{end}}" class="inline" hx-post="/refresh{{if ne .Port 443}}?port{{end}}" hx-target="#results" hx-indicator="#loading" hx-on::before-request="clearResults()">
+            <input type="hidden" name="domain" value="{{.DisplayTarget}}">
             <button type="submit" class="btn-secondary">
                 <span class="htmx-indicator h-4 w-4 animate-spin rounded-full border-2 border-slate-400 border-t-slate-100 dark:border-slate-500 dark:border-t-slate-100"></span>
                 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="h-4 w-4"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M20 11a8.1 8.1 0 0 0 -15.5 -2m-.5 -4v4h4" /><path d="M4 13a8.1 8.1 0 0 0 15.5 2m.5 4v-4h-4" /></svg>

--- a/internal/web/types.go
+++ b/internal/web/types.go
@@ -17,6 +17,7 @@ import (
 // DomainResult represents domain data from the database.
 type DomainResult struct {
 	Domain    string
+	Port      int
 	HasChain  bool
 	Chain     []*CertificateResult
 	UpdatedAt time.Time
@@ -40,12 +41,14 @@ type CertificateResult struct {
 // CrawlOutput represents the output of a crawl operation.
 type CrawlOutput struct {
 	Domain string
+	Port   int
 	Chain  []*CertificateResult
 }
 
 // CrawlResultInput is the input for recording a crawl result.
 type CrawlResultInput struct {
 	Domain  string
+	Port    int
 	Success bool
 	Forced  bool
 	Chain   []*CertificateResult
@@ -94,6 +97,8 @@ type CertViewData struct {
 // ResultsViewData is the view model for the results template.
 type ResultsViewData struct {
 	Domain             string
+	Port               int
+	DisplayTarget      string
 	IsCached           bool
 	CacheAge           string
 	CanForceRefresh    bool
@@ -409,8 +414,14 @@ func assignChainLabelsAndColors(chain []*CertViewData) {
 }
 
 func buildResultsViewData(result *DomainResult, isCached bool, canForce bool, waitTime time.Duration, lastCrawlFailed bool) *ResultsViewData {
+	port := result.Port
+	if port == 0 {
+		port = 443
+	}
 	data := &ResultsViewData{
 		Domain:          result.Domain,
+		Port:            port,
+		DisplayTarget:   formatTarget(result.Domain, port),
 		IsCached:        isCached,
 		CanForceRefresh: canForce,
 		LastCrawlFailed: lastCrawlFailed,
@@ -433,4 +444,11 @@ func buildResultsViewData(result *DomainResult, isCached bool, canForce bool, wa
 	assignChainLabelsAndColors(data.Chain)
 
 	return data
+}
+
+func formatTarget(domain string, port int) string {
+	if port == 0 || port == 443 {
+		return domain
+	}
+	return fmt.Sprintf("%s:%d", domain, port)
 }


### PR DESCRIPTION
## Summary
- add port as part of persisted domain observation identity while defaulting existing records to 443
- allow web inspection and refresh of host:port targets only when ?port is present
- keep certificates and chain objects port-independent while updating docs and tests

## Tests
- go test ./...