### PR TITLE
[codex] Accept port input by default

### DIFF
--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -22,15 +22,13 @@ type IndexData struct {
 	Results    *ResultsViewData
 	Error      *ErrorData
 	ManualMode bool
-	PortMode   bool
 }
 
 // handleIndex serves the main page (GET only, read-only, never triggers crawl).
 func (s *Server) handleIndex(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	_, manualMode := r.URL.Query()["manual"]
-	portMode := r.URL.Query().Has("port")
-	if err := s.templates.ExecuteTemplate(w, "index.html", &IndexData{ManualMode: manualMode, PortMode: portMode}); err != nil {
+	if err := s.templates.ExecuteTemplate(w, "index.html", &IndexData{ManualMode: manualMode}); err != nil {
 		s.logger.Error("failed to render index", "error", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 	}
@@ -192,7 +190,7 @@ func (s *Server) handleInspect(w http.ResponseWriter, r *http.Request) {
 	}
 
 	rawDomain := r.FormValue("domain")
-	target, err := domain.NormalizeAndValidateTarget(rawDomain, r.URL.Query().Has("port"))
+	target, err := domain.NormalizeAndValidateTarget(rawDomain, true)
 	if err != nil {
 		s.renderError(w, r, "Invalid Domain", formatDomainError(err), http.StatusBadRequest)
 		return
@@ -257,7 +255,7 @@ func (s *Server) handleRefresh(w http.ResponseWriter, r *http.Request) {
 	}
 
 	rawDomain := r.FormValue("domain")
-	target, err := domain.NormalizeAndValidateTarget(rawDomain, r.URL.Query().Has("port"))
+	target, err := domain.NormalizeAndValidateTarget(rawDomain, true)
 	if err != nil {
 		s.renderError(w, r, "Invalid Domain", formatDomainError(err), http.StatusBadRequest)
 		return
@@ -627,7 +625,7 @@ func formatDomainError(err error) string {
 	case domain.ErrDomainHasScheme:
 		return "Please enter just the domain name without http:// or https://."
 	case domain.ErrDomainHasPort:
-		return "Please enter just the domain name without a port number."
+		return "Please enter a valid domain name."
 	case domain.ErrInvalidPort:
 		return "Port must be a number between 1 and 65535."
 	case domain.ErrDomainHasPath:
@@ -647,7 +645,7 @@ func formatCrawlError(err error) string {
 		return "Connection failed. The server may be unreachable."
 	}
 	if strings.Contains(errStr, "tls handshake") {
-		return "TLS handshake failed. The server may not support TLS on the requested port."
+		return "TLS handshake failed. The server may not support TLS."
 	}
 	if strings.Contains(errStr, "no certificates") {
 		return "No certificates were returned by the server."

--- a/internal/web/handlers_test.go
+++ b/internal/web/handlers_test.go
@@ -167,7 +167,7 @@ func TestHandleIndex(t *testing.T) {
 	}
 }
 
-func TestHandleIndex_PortModePreservesInspectQuery(t *testing.T) {
+func TestHandleIndex_InspectFormUsesDefaultEndpoint(t *testing.T) {
 	repo := &mockRepository{}
 	crawler := &mockCrawler{}
 
@@ -176,7 +176,7 @@ func TestHandleIndex_PortModePreservesInspectQuery(t *testing.T) {
 		t.Fatalf("Failed to create server: %v", err)
 	}
 
-	req := httptest.NewRequest(http.MethodGet, "/?port", nil)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	w := httptest.NewRecorder()
 
 	server.handleIndex(w, req)
@@ -186,11 +186,11 @@ func TestHandleIndex_PortModePreservesInspectQuery(t *testing.T) {
 	}
 
 	body := w.Body.String()
-	if !strings.Contains(body, `action="/inspect?port"`) {
-		t.Errorf("expected inspect form action to preserve port mode, got: %s", body)
+	if !strings.Contains(body, `action="/inspect"`) {
+		t.Errorf("expected inspect form action to use default endpoint, got: %s", body)
 	}
-	if !strings.Contains(body, `hx-post="/inspect?port"`) {
-		t.Errorf("expected HTMX post target to preserve port mode, got: %s", body)
+	if !strings.Contains(body, `hx-post="/inspect"`) {
+		t.Errorf("expected HTMX post target to use default endpoint, got: %s", body)
 	}
 }
 
@@ -223,7 +223,7 @@ func TestHandleInspect_ValidDomain(t *testing.T) {
 	}
 }
 
-func TestHandleInspect_ValidDomainWithPortMode(t *testing.T) {
+func TestHandleInspect_ValidDomainWithPort(t *testing.T) {
 	repo := &mockRepository{
 		canStandard:  true,
 		canForced:    true,
@@ -239,7 +239,7 @@ func TestHandleInspect_ValidDomainWithPortMode(t *testing.T) {
 	form := url.Values{}
 	form.Set("domain", "smtp.gmail.com:465")
 
-	req := httptest.NewRequest(http.MethodPost, "/inspect?port", strings.NewReader(form.Encode()))
+	req := httptest.NewRequest(http.MethodPost, "/inspect", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.Host = "localhost:8080"
 
@@ -265,7 +265,7 @@ func TestHandleInspect_InvalidDomain(t *testing.T) {
 	}{
 		{"empty domain", "", "enter a domain"},
 		{"url with scheme", "https://example.com", "without http"},
-		{"domain with port", "example.com:443", "without a port"},
+		{"invalid port", "example.com:abc", "Port must be a number"},
 		{"domain with path", "example.com/path", "without any path"},
 		{"ip address", "192.168.1.1", "IP addresses are not allowed"},
 	}
@@ -294,9 +294,6 @@ func TestHandleInspect_InvalidDomain(t *testing.T) {
 			body := w.Body.String()
 			if !strings.Contains(strings.ToLower(body), strings.ToLower(tt.wantErr)) {
 				t.Errorf("Expected error containing %q, got: %s", tt.wantErr, body)
-			}
-			if tt.name == "domain with port" && strings.Contains(body, "?port") {
-				t.Errorf("port-mode error should not disclose hidden query parameter, got: %s", body)
 			}
 		})
 	}

--- a/internal/web/templates/index.html
+++ b/internal/web/templates/index.html
@@ -58,7 +58,7 @@
                 </div>
                 {{else}}
                 <h2 class="panel-title"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="inline-block align-middle" style="margin-right: 0.5rem;"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M21 12a9 9 0 1 0 -9 9" /><path d="M3.6 9h16.8" /><path d="M3.6 15h8.4" /><path d="M11.578 3a17 17 0 0 0 0 18" /><path d="M12.5 3c1.719 2.755 2.5 5.876 2.5 9" /><path d="M18 14v7m-3 -3l3 3l3 -3" /></svg>Retrieve Certificate</h2>
-                <form id="inspect-form" method="POST" action="/inspect{{if .PortMode}}?port{{end}}" class="domain-form" hx-post="/inspect{{if .PortMode}}?port{{end}}" hx-target="#results" hx-indicator="#loading">
+                <form id="inspect-form" method="POST" action="/inspect" class="domain-form" hx-post="/inspect" hx-target="#results" hx-indicator="#loading">
                     <input
                         type="text"
                         name="domain"
@@ -117,7 +117,7 @@
                     </li>
                     <li class="info-row">
                         <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="mt-0.5 h-[18px] w-[18px]"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M12 3a12 12 0 0 0 8.5 3a12 12 0 0 1 -8.5 15a12 12 0 0 1 -8.5 -15a12 12 0 0 0 8.5 -3" /><path d="M11 11a1 1 0 1 0 2 0a1 1 0 0 0 -2 0" /><path d="M12 12l0 2.5" /></svg>
-                        <span><strong>Basic TLS handshake</strong> on the requested port; no HTTP requests, no redirects followed</span>
+                        <span><strong>TLS handshake only</strong>; no HTTP, HTTPS, or redirects</span>
                     </li>
                     <li class="info-row">
                         <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="mt-0.5 h-[18px] w-[18px]"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M12 15a3 3 0 1 0 6 0a3 3 0 1 0 -6 0" /><path d="M13 17.5v4.5l2 -1.5l2 1.5v-4.5" /><path d="M10 19h-5a2 2 0 0 1 -2 -2v-10c0 -1.1 .9 -2 2 -2h14a2 2 0 0 1 2 2v10a2 2 0 0 1 -1 1.73" /><path d="M6 9l12 0" /><path d="M6 12l3 0" /><path d="M6 15l2 0" /></svg>

--- a/internal/web/templates/results.html
+++ b/internal/web/templates/results.html
@@ -15,7 +15,7 @@
             {{end}}
         </div>
         {{if and .CanForceRefresh .IsCached}}
-        <form method="POST" action="/refresh{{if ne .Port 443}}?port{{end}}" class="inline" hx-post="/refresh{{if ne .Port 443}}?port{{end}}" hx-target="#results" hx-indicator="#loading" hx-on::before-request="clearResults()">
+        <form method="POST" action="/refresh" class="inline" hx-post="/refresh" hx-target="#results" hx-indicator="#loading" hx-on::before-request="clearResults()">
             <input type="hidden" name="domain" value="{{.DisplayTarget}}">
             <button type="submit" class="btn-secondary">
                 <span class="htmx-indicator h-4 w-4 animate-spin rounded-full border-2 border-slate-400 border-t-slate-100 dark:border-slate-500 dark:border-t-slate-100"></span>


### PR DESCRIPTION
## Summary
- accept host:port input through the normal inspect and refresh endpoints
- remove the old query-flag form routing and related test expectations
- update observation copy to describe TLS-only retrieval without protocol handling

## Validation
- go test ./...
- Playwright: verified / accepts smtp.gmail.com:465 and refresh posts to /refresh with the host:port value

No database migrations are required; this changes only web parsing/templates/tests.