### PR TITLE
[codex] Add certificate decode tabs

### DIFF
--- a/internal/web/static/css/style.css
+++ b/internal/web/static/css/style.css
@@ -35,7 +35,9 @@
     --color-emerald-700: oklch(50.8% 0.118 165.612);
     --color-emerald-900: oklch(37.8% 0.077 168.94);
     --color-sky-100: oklch(95.1% 0.026 236.824);
+    --color-sky-300: oklch(82.8% 0.111 230.318);
     --color-sky-400: oklch(74.6% 0.16 232.661);
+    --color-sky-700: oklch(50% 0.134 242.749);
     --color-sky-900: oklch(39.1% 0.09 240.876);
     --color-blue-50: oklch(97% 0.014 254.604);
     --color-blue-100: oklch(93.2% 0.032 255.585);
@@ -1869,6 +1871,36 @@ a {
   }
   &:where(.dark, .dark *) {
     color: var(--color-slate-300);
+  }
+}
+.ca-issuers-list {
+  display: flex;
+  flex-direction: column;
+  gap: calc(var(--spacing) * 1);
+}
+.ca-issuers-link {
+  word-break: break-all;
+  color: var(--color-sky-700);
+  text-decoration-line: underline;
+  text-decoration-color: var(--color-sky-300);
+  text-underline-offset: 2px;
+  &:hover {
+    @media (hover: hover) {
+      color: var(--color-orange-700);
+    }
+  }
+  &:where(.dark, .dark *) {
+    color: var(--color-sky-300);
+  }
+  &:where(.dark, .dark *) {
+    text-decoration-color: var(--color-sky-700);
+  }
+  &:where(.dark, .dark *) {
+    &:hover {
+      @media (hover: hover) {
+        color: var(--color-orange-300);
+      }
+    }
   }
 }
 .chain-section {

--- a/internal/web/static/css/style.css
+++ b/internal/web/static/css/style.css
@@ -1622,6 +1622,85 @@ a {
     }
   }
 }
+.details-column {
+  min-width: calc(var(--spacing) * 0);
+  padding: calc(var(--spacing) * 4);
+}
+.cert-tab-list {
+  margin-bottom: calc(var(--spacing) * 3);
+  display: inline-flex;
+  border-radius: var(--radius-lg);
+  border-style: var(--tw-border-style);
+  border-width: 1px;
+  border-color: var(--color-slate-200);
+  background-color: var(--color-slate-100);
+  padding: calc(var(--spacing) * 1);
+  --tw-shadow: 0 1px 3px 0 var(--tw-shadow-color, rgb(0 0 0 / 0.1)), 0 1px 2px -1px var(--tw-shadow-color, rgb(0 0 0 / 0.1));
+  box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  &:where(.dark, .dark *) {
+    border-color: var(--color-slate-700);
+  }
+  &:where(.dark, .dark *) {
+    background-color: var(--color-slate-950);
+  }
+}
+.cert-tab-button {
+  border-radius: var(--radius-md);
+  padding-inline: calc(var(--spacing) * 3);
+  padding-block: calc(var(--spacing) * 1.5);
+  font-size: var(--text-xs);
+  line-height: var(--tw-leading, var(--text-xs--line-height));
+  --tw-font-weight: var(--font-weight-semibold);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-slate-600);
+  transition-property: color, background-color, border-color, outline-color, text-decoration-color, fill, stroke, --tw-gradient-from, --tw-gradient-via, --tw-gradient-to;
+  transition-timing-function: var(--tw-ease, var(--default-transition-timing-function));
+  transition-duration: var(--tw-duration, var(--default-transition-duration));
+  &:hover {
+    @media (hover: hover) {
+      color: var(--color-slate-950);
+    }
+  }
+  &:focus {
+    --tw-ring-shadow: var(--tw-ring-inset,) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color, currentcolor);
+    box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  }
+  &:focus {
+    --tw-ring-color: color-mix(in srgb, oklch(70.5% 0.213 47.604) 40%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      --tw-ring-color: color-mix(in oklab, var(--color-orange-500) 40%, transparent);
+    }
+  }
+  &:focus {
+    --tw-outline-style: none;
+    outline-style: none;
+  }
+  &:where(.dark, .dark *) {
+    color: var(--color-slate-300);
+  }
+  &:where(.dark, .dark *) {
+    &:hover {
+      @media (hover: hover) {
+        color: var(--color-slate-50);
+      }
+    }
+  }
+}
+.cert-tab-button.is-active {
+  background-color: var(--color-white);
+  color: var(--color-orange-700);
+  --tw-shadow: 0 1px 3px 0 var(--tw-shadow-color, rgb(0 0 0 / 0.1)), 0 1px 2px -1px var(--tw-shadow-color, rgb(0 0 0 / 0.1));
+  box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  &:where(.dark, .dark *) {
+    background-color: var(--color-slate-800);
+  }
+  &:where(.dark, .dark *) {
+    color: var(--color-orange-300);
+  }
+}
+.cert-tab-panel {
+  min-width: calc(var(--spacing) * 0);
+}
 .details-stack {
   min-width: calc(var(--spacing) * 0);
   :where(& > :not(:last-child)) {
@@ -1629,7 +1708,36 @@ a {
     margin-block-start: calc(calc(var(--spacing) * 3) * var(--tw-space-y-reverse));
     margin-block-end: calc(calc(var(--spacing) * 3) * calc(1 - var(--tw-space-y-reverse)));
   }
-  padding: calc(var(--spacing) * 4);
+}
+.advanced-decode {
+  margin: calc(var(--spacing) * 0);
+  max-height: 500px;
+  min-height: 18rem;
+  width: 100%;
+  overflow: auto;
+  border-radius: var(--radius-lg);
+  border-style: var(--tw-border-style);
+  border-width: 1px;
+  border-color: var(--color-slate-200);
+  background-color: var(--color-slate-100);
+  padding: calc(var(--spacing) * 3);
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  --tw-leading: 1.45;
+  line-height: 1.45;
+  white-space: pre;
+  color: var(--color-slate-700);
+  --tw-shadow: inset 0 2px 4px 0 var(--tw-shadow-color, rgb(0 0 0 / 0.05));
+  box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  &:where(.dark, .dark *) {
+    border-color: var(--color-slate-700);
+  }
+  &:where(.dark, .dark *) {
+    background-color: var(--color-slate-950);
+  }
+  &:where(.dark, .dark *) {
+    color: var(--color-slate-300);
+  }
 }
 .detail-grid {
   display: grid;
@@ -2001,7 +2109,7 @@ a {
   }
 }
 @media (max-width: 1000px) {
-  .pem-block {
+  .pem-block, .advanced-decode {
     max-height: 200px;
   }
 }

--- a/internal/web/static/js/script.js
+++ b/internal/web/static/js/script.js
@@ -80,6 +80,26 @@ function copyPEM(button, certHash) {
     }
 }
 
+function switchCertDecodeTab(button, selected) {
+    var root = button && button.closest ? button.closest("[data-cert-tabs]") : null;
+    if (!root) {
+        return;
+    }
+
+    var buttons = root.querySelectorAll("[data-cert-tab-button]");
+    for (var i = 0; i < buttons.length; i++) {
+        var isActive = buttons[i].dataset.certTabButton === selected;
+        buttons[i].classList.toggle("is-active", isActive);
+        buttons[i].setAttribute("aria-selected", String(isActive));
+    }
+
+    var panels = root.querySelectorAll("[data-cert-tab-panel]");
+    for (var j = 0; j < panels.length; j++) {
+        var isSelected = panels[j].dataset.certTabPanel === selected;
+        panels[j].classList.toggle("hidden", !isSelected);
+    }
+}
+
 // Mermaid click callback: maps Mermaid node IDs to certificate indices.
 function selectTrustPathCertFromMermaid(nodeId) {
     var mapEntries = document.querySelectorAll(".tp-node-map");

--- a/internal/web/tailwind.css
+++ b/internal/web/tailwind.css
@@ -457,6 +457,15 @@ a {
   @apply dark:bg-slate-800 dark:text-slate-300;
 }
 
+.ca-issuers-list {
+  @apply flex flex-col gap-1;
+}
+
+.ca-issuers-link {
+  @apply break-all text-sky-700 underline decoration-sky-300 underline-offset-2 hover:text-orange-700;
+  @apply dark:text-sky-300 dark:decoration-sky-700 dark:hover:text-orange-300;
+}
+
 .chain-section {
   @apply mt-8;
 }

--- a/internal/web/tailwind.css
+++ b/internal/web/tailwind.css
@@ -368,8 +368,37 @@ a {
   @apply hover:bg-slate-100 hover:text-slate-900 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700 dark:hover:text-slate-100;
 }
 
+.details-column {
+  @apply min-w-0 p-4;
+}
+
+.cert-tab-list {
+  @apply mb-3 inline-flex rounded-lg border border-slate-200 bg-slate-100 p-1 shadow-sm;
+  @apply dark:border-slate-700 dark:bg-slate-950;
+}
+
+.cert-tab-button {
+  @apply rounded-md px-3 py-1.5 text-xs font-semibold text-slate-600 transition-colors;
+  @apply hover:text-slate-950 focus:outline-none focus:ring-2 focus:ring-orange-500/40;
+  @apply dark:text-slate-300 dark:hover:text-slate-50;
+}
+
+.cert-tab-button.is-active {
+  @apply bg-white text-orange-700 shadow-sm;
+  @apply dark:bg-slate-800 dark:text-orange-300;
+}
+
+.cert-tab-panel {
+  @apply min-w-0;
+}
+
 .details-stack {
-  @apply min-w-0 space-y-3 p-4;
+  @apply min-w-0 space-y-3;
+}
+
+.advanced-decode {
+  @apply m-0 max-h-[500px] min-h-[18rem] w-full overflow-auto whitespace-pre rounded-lg border border-slate-200 bg-slate-100 p-3 font-mono text-[0.68rem] leading-[1.45] text-slate-700 shadow-inner;
+  @apply dark:border-slate-700 dark:bg-slate-950 dark:text-slate-300;
 }
 
 .detail-grid {
@@ -610,7 +639,8 @@ a {
 }
 
 @media (max-width: 1000px) {
-  .pem-block {
+  .pem-block,
+  .advanced-decode {
     max-height: 200px;
   }
 }

--- a/internal/web/templates/results.html
+++ b/internal/web/templates/results.html
@@ -90,7 +90,13 @@
                             </button>
                         </div>
                     </div>
-                    <div class="details-stack">
+                    <div class="details-column" data-cert-tabs>
+                        <div class="cert-tab-list" role="tablist" aria-label="Certificate decode view">
+                            <button type="button" class="cert-tab-button is-active" role="tab" aria-selected="true" data-cert-tab-button="basic" onclick="switchCertDecodeTab(this, 'basic')">Basic</button>
+                            <button type="button" class="cert-tab-button" role="tab" aria-selected="false" data-cert-tab-button="advanced" onclick="switchCertDecodeTab(this, 'advanced')">Advanced</button>
+                        </div>
+                        <div class="cert-tab-panel" data-cert-tab-panel="basic">
+                        <div class="details-stack">
                         <div class="detail-grid">
                             <div class="detail-item">
                                 <div class="detail-label">Subject</div>
@@ -203,6 +209,11 @@
                             <div class="detail-box detail-box-mono hex-value">{{$gc.SHA1Fingerprint}}</div>
                         </div>
                         {{end}}
+                        </div>
+                        </div>
+                        <div class="cert-tab-panel hidden" data-cert-tab-panel="advanced">
+                            <pre class="advanced-decode">{{$gc.AdvancedDecode}}</pre>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -240,7 +251,13 @@
                             </button>
                         </div>
                     </div>
-                    <div class="details-stack">
+                    <div class="details-column" data-cert-tabs>
+                        <div class="cert-tab-list" role="tablist" aria-label="Certificate decode view">
+                            <button type="button" class="cert-tab-button is-active" role="tab" aria-selected="true" data-cert-tab-button="basic" onclick="switchCertDecodeTab(this, 'basic')">Basic</button>
+                            <button type="button" class="cert-tab-button" role="tab" aria-selected="false" data-cert-tab-button="advanced" onclick="switchCertDecodeTab(this, 'advanced')">Advanced</button>
+                        </div>
+                        <div class="cert-tab-panel" data-cert-tab-panel="basic">
+                        <div class="details-stack">
                         <div class="detail-grid">
                             <div class="detail-item">
                                 <div class="detail-label">Subject</div>
@@ -363,6 +380,11 @@
                             <div class="detail-box detail-box-mono hex-value">{{$cert.SHA1Fingerprint}}</div>
                         </div>
                         {{end}}
+                        </div>
+                        </div>
+                        <div class="cert-tab-panel hidden" data-cert-tab-panel="advanced">
+                            <pre class="advanced-decode">{{$cert.AdvancedDecode}}</pre>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/internal/web/templates/results.html
+++ b/internal/web/templates/results.html
@@ -171,6 +171,18 @@
                             <div class="detail-box">{{$gc.ExtKeyUsage}}</div>
                         </div>
                         {{end}}
+                        {{if $gc.CAIssuersURLs}}
+                        <div class="detail-item">
+                            <div class="detail-label">CA Issuers URL</div>
+                            <div class="detail-box detail-box-mono">
+                                <div class="ca-issuers-list">
+                                    {{range $gc.CAIssuersURLs}}
+                                    <a class="ca-issuers-link" href="{{.}}" rel="noopener noreferrer" target="_blank">{{.}}</a>
+                                    {{end}}
+                                </div>
+                            </div>
+                        </div>
+                        {{end}}
                         {{if $gc.SANs}}
                         <div class="detail-item">
                             <div class="detail-label">Subject Alternative Names ({{len $gc.SANs}})</div>
@@ -337,6 +349,18 @@
                         <div class="detail-item">
                             <div class="detail-label">Extended Key Usage</div>
                             <div class="detail-box">{{$cert.ExtKeyUsage}}</div>
+                        </div>
+                        {{end}}
+                        {{if $cert.CAIssuersURLs}}
+                        <div class="detail-item">
+                            <div class="detail-label">CA Issuers URL</div>
+                            <div class="detail-box detail-box-mono">
+                                <div class="ca-issuers-list">
+                                    {{range $cert.CAIssuersURLs}}
+                                    <a class="ca-issuers-link" href="{{.}}" rel="noopener noreferrer" target="_blank">{{.}}</a>
+                                    {{end}}
+                                </div>
+                            </div>
                         </div>
                         {{end}}
 

--- a/internal/web/types.go
+++ b/internal/web/types.go
@@ -81,6 +81,7 @@ type CertViewData struct {
 	SignatureAlgorithm   string
 	PublicKeyInfo        string
 	SANs                 []string
+	CAIssuersURLs        []string
 	KeyUsage             string
 	ExtKeyUsage          string
 	SKI                  string
@@ -179,6 +180,7 @@ func populateFromParsedCert(view *CertViewData, cert *x509.Certificate) {
 			view.SANs = append(view.SANs, "Email:"+email)
 		}
 	}
+	view.CAIssuersURLs = append(view.CAIssuersURLs, cert.IssuingCertificateURL...)
 
 	// Key Usage
 	view.KeyUsage = formatKeyUsage(cert.KeyUsage)

--- a/internal/web/types.go
+++ b/internal/web/types.go
@@ -6,6 +6,8 @@ import (
 	"crypto/sha1"
 	"crypto/sha256"
 	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
 	"encoding/hex"
 	"fmt"
 	"strings"
@@ -85,6 +87,7 @@ type CertViewData struct {
 	AKI                  string
 	SHA1Fingerprint      string
 	SHA256Fingerprint    string
+	AdvancedDecode       string
 	PossibleIssuers      []string
 	// CertLabel is the human-readable label for this certificate's role in the chain
 	CertLabel string
@@ -162,6 +165,7 @@ func populateFromParsedCert(view *CertViewData, cert *x509.Certificate) {
 	view.SerialNumber = formatSerialNumber(cert.SerialNumber.Bytes())
 	view.SignatureAlgorithm = cert.SignatureAlgorithm.String()
 	view.PublicKeyInfo = formatPublicKey(cert)
+	view.AdvancedDecode = formatAdvancedCertificate(cert)
 
 	// Subject Alternative Names
 	if len(cert.DNSNames) > 0 || len(cert.IPAddresses) > 0 || len(cert.EmailAddresses) > 0 {
@@ -189,6 +193,158 @@ func populateFromParsedCert(view *CertViewData, cert *x509.Certificate) {
 		sha256Sum := sha256.Sum256(cert.Raw)
 		view.SHA256Fingerprint = formatHexBytes(sha256Sum[:])
 	}
+}
+
+func formatAdvancedCertificate(cert *x509.Certificate) string {
+	var b strings.Builder
+
+	writeAdvancedLine(&b, 0, "Certificate:")
+	writeAdvancedLine(&b, 1, "Data:")
+	writeAdvancedLine(&b, 2, "Version: %d (0x%x)", cert.Version, cert.Version-1)
+	writeAdvancedLine(&b, 2, "Serial Number:")
+	writeWrappedHex(&b, 3, cert.SerialNumber.Bytes(), 15)
+	writeAdvancedLine(&b, 2, "Signature Algorithm: %s", cert.SignatureAlgorithm)
+	writeAdvancedLine(&b, 2, "Issuer: %s", cert.Issuer.String())
+	writeAdvancedLine(&b, 2, "Validity")
+	writeAdvancedLine(&b, 3, "Not Before: %s", cert.NotBefore.UTC().Format("Jan 02 15:04:05 2006 GMT"))
+	writeAdvancedLine(&b, 3, "Not After : %s", cert.NotAfter.UTC().Format("Jan 02 15:04:05 2006 GMT"))
+	writeAdvancedLine(&b, 2, "Subject: %s", cert.Subject.String())
+	writeAdvancedLine(&b, 2, "Subject Public Key Info:")
+	writeAdvancedLine(&b, 3, "Public Key Algorithm: %s", cert.PublicKeyAlgorithm)
+	writeAdvancedLine(&b, 3, "Public-Key: %s", formatPublicKey(cert))
+
+	if len(cert.DNSNames) > 0 || len(cert.IPAddresses) > 0 || len(cert.EmailAddresses) > 0 || len(cert.URIs) > 0 {
+		writeAdvancedLine(&b, 2, "Subject Alternative Name:")
+		writeAdvancedLine(&b, 3, "%s", formatSubjectAlternativeNames(cert))
+	}
+
+	writeAdvancedLine(&b, 2, "X509v3 extensions:")
+	for _, ext := range cert.Extensions {
+		writeAdvancedExtension(&b, ext)
+	}
+	if len(cert.UnhandledCriticalExtensions) > 0 {
+		writeAdvancedLine(&b, 2, "Unhandled Critical Extensions:")
+		for _, oid := range cert.UnhandledCriticalExtensions {
+			writeAdvancedLine(&b, 3, "%s", oid.String())
+		}
+	}
+
+	writeAdvancedLine(&b, 1, "Signature Algorithm: %s", cert.SignatureAlgorithm)
+	writeWrappedHex(&b, 2, cert.Signature, 18)
+
+	return strings.TrimRight(b.String(), "\n")
+}
+
+func writeAdvancedLine(b *strings.Builder, indent int, format string, args ...interface{}) {
+	b.WriteString(strings.Repeat("    ", indent))
+	fmt.Fprintf(b, format, args...)
+	b.WriteByte('\n')
+}
+
+func writeWrappedHex(b *strings.Builder, indent int, data []byte, perLine int) {
+	if len(data) == 0 {
+		writeAdvancedLine(b, indent, "<empty>")
+		return
+	}
+	for start := 0; start < len(data); start += perLine {
+		end := start + perLine
+		if end > len(data) {
+			end = len(data)
+		}
+		writeAdvancedLine(b, indent, "%s", formatHexBytes(data[start:end]))
+	}
+}
+
+func writeAdvancedExtension(b *strings.Builder, ext pkix.Extension) {
+	name := extensionName(ext.Id)
+	critical := ""
+	if ext.Critical {
+		critical = " critical"
+	}
+	writeAdvancedLine(b, 3, "%s%s:", name, critical)
+
+	if formatted, ok := formatKnownExtension(ext); ok {
+		for _, line := range strings.Split(formatted, "\n") {
+			writeAdvancedLine(b, 4, "%s", line)
+		}
+		return
+	}
+
+	writeWrappedHex(b, 4, ext.Value, 16)
+}
+
+func extensionName(oid asn1.ObjectIdentifier) string {
+	known := map[string]string{
+		"2.5.29.14":               "X509v3 Subject Key Identifier",
+		"2.5.29.15":               "X509v3 Key Usage",
+		"2.5.29.17":               "X509v3 Subject Alternative Name",
+		"2.5.29.19":               "X509v3 Basic Constraints",
+		"2.5.29.31":               "X509v3 CRL Distribution Points",
+		"2.5.29.32":               "X509v3 Certificate Policies",
+		"2.5.29.35":               "X509v3 Authority Key Identifier",
+		"2.5.29.37":               "X509v3 Extended Key Usage",
+		"1.3.6.1.5.5.7.1.1":       "Authority Information Access",
+		"1.3.6.1.5.5.7.1.12":      "X509v3 Logotype",
+		"1.3.6.1.4.1.11129.2.4.2": "CT Precertificate SCTs",
+	}
+	if name, ok := known[oid.String()]; ok {
+		return name
+	}
+	return oid.String()
+}
+
+func formatKnownExtension(ext pkix.Extension) (string, bool) {
+	switch ext.Id.String() {
+	case "2.5.29.14", "2.5.29.35":
+		var keyID []byte
+		if _, err := asn1.Unmarshal(ext.Value, &keyID); err == nil && len(keyID) > 0 {
+			return formatHexBytes(keyID), true
+		}
+	case "2.5.29.15":
+		return formatBitStringExtension(ext.Value), true
+	case "2.5.29.19":
+		return formatBasicConstraintsExtension(ext.Value), true
+	}
+	return "", false
+}
+
+func formatBitStringExtension(value []byte) string {
+	var bits asn1.BitString
+	if _, err := asn1.Unmarshal(value, &bits); err != nil {
+		return formatHexBytes(value)
+	}
+	return formatHexBytes(bits.Bytes)
+}
+
+func formatBasicConstraintsExtension(value []byte) string {
+	var bc struct {
+		IsCA       bool `asn1:"optional"`
+		MaxPathLen int  `asn1:"optional,default:-1"`
+	}
+	if _, err := asn1.Unmarshal(value, &bc); err != nil {
+		return formatHexBytes(value)
+	}
+	if bc.MaxPathLen >= 0 {
+		return fmt.Sprintf("CA:%t, pathlen:%d", bc.IsCA, bc.MaxPathLen)
+	}
+	return fmt.Sprintf("CA:%t", bc.IsCA)
+}
+
+func formatSubjectAlternativeNames(cert *x509.Certificate) string {
+	var names []string
+	for _, name := range cert.DNSNames {
+		names = append(names, "DNS:"+name)
+	}
+	for _, ip := range cert.IPAddresses {
+		names = append(names, "IP Address:"+ip.String())
+	}
+	for _, email := range cert.EmailAddresses {
+		names = append(names, "email:"+email)
+	}
+	for _, uri := range cert.URIs {
+		names = append(names, "URI:"+uri.String())
+	}
+	return strings.Join(names, ", ")
 }
 
 func extractCN(dn string) string {

--- a/internal/web/types_test.go
+++ b/internal/web/types_test.go
@@ -166,6 +166,49 @@ func TestCertToViewData_Fingerprints(t *testing.T) {
 	}
 }
 
+func TestCertToViewData_CAIssuersURLs(t *testing.T) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate ECDSA key: %v", err)
+	}
+
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test"},
+		NotBefore:             time.Now().Add(-24 * time.Hour),
+		NotAfter:              time.Now().Add(365 * 24 * time.Hour),
+		BasicConstraintsValid: true,
+		IssuingCertificateURL: []string{
+			"http://cacerts.digicert.cn/DigiCertGlobalRootG2.crt",
+			"http://cacerts.digicert.com/DigiCertGlobalRootG2.crt",
+		},
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("failed to create certificate: %v", err)
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatalf("failed to parse certificate: %v", err)
+	}
+
+	view := certToViewData(&CertificateResult{
+		CertHash:  make([]byte, 32),
+		PEM:       "-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----\n",
+		NotBefore: cert.NotBefore,
+		NotAfter:  cert.NotAfter,
+		Parsed:    cert,
+	})
+
+	if len(view.CAIssuersURLs) != 2 {
+		t.Fatalf("certToViewData CAIssuersURLs count = %d, want 2", len(view.CAIssuersURLs))
+	}
+	if view.CAIssuersURLs[0] != "http://cacerts.digicert.cn/DigiCertGlobalRootG2.crt" {
+		t.Errorf("first CA Issuers URL = %q", view.CAIssuersURLs[0])
+	}
+}
+
 func TestFormatHexBytes_Lowercase(t *testing.T) {
 	input := []byte{0xF8, 0x87, 0x8B, 0x2D, 0xBD}
 	result := formatHexBytes(input)


### PR DESCRIPTION
## Summary
- add Basic and Advanced tabs to each certificate detail pane
- render an advanced monospace certificate decode from parsed x509 data
- keep the advanced decode scroll-bounded alongside the PEM column
- regenerate committed Tailwind CSS

## Validation
- go test ./...
- go build ./...