### PR TITLE
[codex] Allow manual import of existing certificates

### DIFF
--- a/internal/db/web_repository.go
+++ b/internal/db/web_repository.go
@@ -337,6 +337,21 @@ func parseCertificateDER(der []byte) *x509.Certificate {
 	return info.Parsed
 }
 
+// CertificateExists checks whether a certificate is already present in the catalog.
+func (r *WebRepository) CertificateExists(ctx context.Context, hash []byte) (bool, error) {
+	var exists bool
+	if err := r.db.QueryRowContext(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM certificates
+			WHERE cert_hash = $1
+		)
+	`, hash).Scan(&exists); err != nil {
+		return false, fmt.Errorf("check certificate exists: %w", err)
+	}
+	return exists, nil
+}
+
 // FindCertificatesBySKI finds certificates whose SKI matches the given value.
 func (r *WebRepository) FindCertificatesBySKI(ctx context.Context, ski []byte) ([]*web.CertificateResult, error) {
 	if len(ski) == 0 {

--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -181,6 +181,15 @@ func (s *Server) validateManualCertificate(ctx context.Context, cert *Certificat
 	if cert == nil || cert.Parsed == nil {
 		return fmt.Errorf("certificate could not be parsed")
 	}
+
+	exists, err := s.repo.CertificateExists(ctx, cert.CertHash)
+	if err != nil {
+		return fmt.Errorf("check existing certificate: %w", err)
+	}
+	if exists {
+		return nil
+	}
+
 	if now.Before(cert.Parsed.NotBefore) {
 		return fmt.Errorf("certificate is not valid until %s", cert.Parsed.NotBefore.Format(time.RFC3339))
 	}

--- a/internal/web/handlers_test.go
+++ b/internal/web/handlers_test.go
@@ -21,15 +21,16 @@ import (
 
 // mockRepository implements the Repository interface for testing.
 type mockRepository struct {
-	domainResult      *DomainResult
-	certificateResult *CertificateResult
-	skiCertificates   []*CertificateResult
-	canStandard       bool
-	standardWait      time.Duration
-	canForced         bool
-	forcedWait        time.Duration
-	lockAcquired      bool
-	crawlResults      []*CrawlResultInput
+	domainResult       *DomainResult
+	certificateResult  *CertificateResult
+	storedCertificates map[string]*CertificateResult
+	skiCertificates    []*CertificateResult
+	canStandard        bool
+	standardWait       time.Duration
+	canForced          bool
+	forcedWait         time.Duration
+	lockAcquired       bool
+	crawlResults       []*CrawlResultInput
 }
 
 func (m *mockRepository) GetDomainWithChain(ctx context.Context, domain string) (*DomainResult, error) {
@@ -44,10 +45,23 @@ func (m *mockRepository) GetDomainWithChainForPort(ctx context.Context, domain s
 }
 
 func (m *mockRepository) GetCertificateByHash(ctx context.Context, hash []byte) (*CertificateResult, error) {
+	if m.storedCertificates != nil {
+		if cert := m.storedCertificates[string(hash)]; cert != nil {
+			return cert, nil
+		}
+	}
 	if m.certificateResult != nil {
 		return m.certificateResult, nil
 	}
 	return nil, context.DeadlineExceeded
+}
+
+func (m *mockRepository) CertificateExists(ctx context.Context, hash []byte) (bool, error) {
+	if m.storedCertificates != nil {
+		_, ok := m.storedCertificates[string(hash)]
+		return ok, nil
+	}
+	return false, nil
 }
 
 func (m *mockRepository) FindCertificatesBySKI(ctx context.Context, ski []byte) ([]*CertificateResult, error) {
@@ -738,6 +752,39 @@ func TestHandleManualCert_SelfSigned(t *testing.T) {
 	}
 	if !strings.Contains(w.Body.String(), "Untrusted") {
 		t.Errorf("expected untrusted error for self-signed cert with no DB match, got: %s", w.Body.String())
+	}
+}
+
+func TestHandleManualCert_AlreadyStoredSelfSignedSucceeds(t *testing.T) {
+	caCert, _ := generateTestCA(t)
+	caResult := makeCertResult(caCert)
+
+	repo := &mockRepository{
+		storedCertificates: map[string]*CertificateResult{
+			string(caResult.CertHash): caResult,
+		},
+	}
+	crawler := &mockCrawler{}
+	server, err := New(DefaultConfig(), repo, crawler)
+	if err != nil {
+		t.Fatalf("create server: %v", err)
+	}
+
+	form := url.Values{}
+	form.Set("pem", pemEncodeTest(caCert.Raw))
+	req := httptest.NewRequest(http.MethodPost, "/manual", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("HX-Request", "true")
+	req.Host = "localhost:8080"
+
+	w := httptest.NewRecorder()
+	server.handleManualCert(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 for already stored self-signed cert, got %d: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "manual import") {
+		t.Errorf("expected 'manual import' status chip in results, got: %s", w.Body.String())
 	}
 }
 

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -70,6 +70,8 @@ type Repository interface {
 	GetDomainWithChainForPort(ctx context.Context, domain string, port int) (*DomainResult, error)
 	// GetCertificateByHash retrieves a certificate by its hash.
 	GetCertificateByHash(ctx context.Context, hash []byte) (*CertificateResult, error)
+	// CertificateExists checks whether a certificate is already present in the catalog.
+	CertificateExists(ctx context.Context, hash []byte) (bool, error)
 	// FindCertificatesBySKI finds certificates whose SKI matches the given value.
 	// Used for building the certificate trust path graph.
 	FindCertificatesBySKI(ctx context.Context, ski []byte) ([]*CertificateResult, error)


### PR DESCRIPTION
## Summary
- allow manual import validation to succeed immediately for certificates already present in the catalog
- add an explicit certificate existence repository check
- cover already stored self-signed/root certificates with a regression test

## Validation
- go test ./internal/web/...
- go test ./...