### PR TITLE
[codex] Reorganize certificate detail tabs

### DIFF
--- a/internal/web/static/css/style.css
+++ b/internal/web/static/css/style.css
@@ -1629,38 +1629,38 @@ a {
   padding: calc(var(--spacing) * 4);
 }
 .cert-tab-list {
-  margin-bottom: calc(var(--spacing) * 3);
-  display: inline-flex;
-  border-radius: var(--radius-lg);
-  border-style: var(--tw-border-style);
-  border-width: 1px;
+  margin-bottom: calc(var(--spacing) * 4);
+  display: flex;
+  border-bottom-style: var(--tw-border-style);
+  border-bottom-width: 1px;
   border-color: var(--color-slate-200);
-  background-color: var(--color-slate-100);
-  padding: calc(var(--spacing) * 1);
-  --tw-shadow: 0 1px 3px 0 var(--tw-shadow-color, rgb(0 0 0 / 0.1)), 0 1px 2px -1px var(--tw-shadow-color, rgb(0 0 0 / 0.1));
-  box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
   &:where(.dark, .dark *) {
     border-color: var(--color-slate-700);
   }
-  &:where(.dark, .dark *) {
-    background-color: var(--color-slate-950);
-  }
 }
 .cert-tab-button {
-  border-radius: var(--radius-md);
-  padding-inline: calc(var(--spacing) * 3);
-  padding-block: calc(var(--spacing) * 1.5);
-  font-size: var(--text-xs);
-  line-height: var(--tw-leading, var(--text-xs--line-height));
+  margin-bottom: -1px;
+  border-bottom-style: var(--tw-border-style);
+  border-bottom-width: 2px;
+  border-color: transparent;
+  padding-inline: calc(var(--spacing) * 4);
+  padding-block: calc(var(--spacing) * 2);
+  font-size: var(--text-sm);
+  line-height: var(--tw-leading, var(--text-sm--line-height));
   --tw-font-weight: var(--font-weight-semibold);
   font-weight: var(--font-weight-semibold);
-  color: var(--color-slate-600);
+  color: var(--color-slate-500);
   transition-property: color, background-color, border-color, outline-color, text-decoration-color, fill, stroke, --tw-gradient-from, --tw-gradient-via, --tw-gradient-to;
   transition-timing-function: var(--tw-ease, var(--default-transition-timing-function));
   transition-duration: var(--tw-duration, var(--default-transition-duration));
   &:hover {
     @media (hover: hover) {
-      color: var(--color-slate-950);
+      border-color: var(--color-slate-300);
+    }
+  }
+  &:hover {
+    @media (hover: hover) {
+      color: var(--color-slate-900);
     }
   }
   &:focus {
@@ -1678,23 +1678,28 @@ a {
     outline-style: none;
   }
   &:where(.dark, .dark *) {
-    color: var(--color-slate-300);
+    color: var(--color-slate-400);
   }
   &:where(.dark, .dark *) {
     &:hover {
       @media (hover: hover) {
-        color: var(--color-slate-50);
+        border-color: var(--color-slate-500);
+      }
+    }
+  }
+  &:where(.dark, .dark *) {
+    &:hover {
+      @media (hover: hover) {
+        color: var(--color-slate-100);
       }
     }
   }
 }
 .cert-tab-button.is-active {
-  background-color: var(--color-white);
+  border-color: var(--color-orange-500);
   color: var(--color-orange-700);
-  --tw-shadow: 0 1px 3px 0 var(--tw-shadow-color, rgb(0 0 0 / 0.1)), 0 1px 2px -1px var(--tw-shadow-color, rgb(0 0 0 / 0.1));
-  box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
   &:where(.dark, .dark *) {
-    background-color: var(--color-slate-800);
+    border-color: var(--color-orange-400);
   }
   &:where(.dark, .dark *) {
     color: var(--color-orange-300);
@@ -1707,8 +1712,35 @@ a {
   min-width: calc(var(--spacing) * 0);
   :where(& > :not(:last-child)) {
     --tw-space-y-reverse: 0;
+    margin-block-start: calc(calc(var(--spacing) * 5) * var(--tw-space-y-reverse));
+    margin-block-end: calc(calc(var(--spacing) * 5) * calc(1 - var(--tw-space-y-reverse)));
+  }
+}
+.cert-detail-section {
+  min-width: calc(var(--spacing) * 0);
+  :where(& > :not(:last-child)) {
+    --tw-space-y-reverse: 0;
     margin-block-start: calc(calc(var(--spacing) * 3) * var(--tw-space-y-reverse));
     margin-block-end: calc(calc(var(--spacing) * 3) * calc(1 - var(--tw-space-y-reverse)));
+  }
+}
+.detail-section-title {
+  border-bottom-style: var(--tw-border-style);
+  border-bottom-width: 1px;
+  border-color: color-mix(in srgb, oklch(70.5% 0.213 47.604) 35%, transparent);
+  @supports (color: color-mix(in lab, red, red)) {
+    border-color: color-mix(in oklab, var(--color-orange-500) 35%, transparent);
+  }
+  padding-bottom: calc(var(--spacing) * 1);
+  font-size: 0.68rem;
+  --tw-font-weight: var(--font-weight-semibold);
+  font-weight: var(--font-weight-semibold);
+  --tw-tracking: 0.08em;
+  letter-spacing: 0.08em;
+  color: var(--color-orange-600);
+  text-transform: uppercase;
+  &:where(.dark, .dark *) {
+    color: var(--color-orange-400);
   }
 }
 .advanced-decode {

--- a/internal/web/tailwind.css
+++ b/internal/web/tailwind.css
@@ -373,19 +373,19 @@ a {
 }
 
 .cert-tab-list {
-  @apply mb-3 inline-flex rounded-lg border border-slate-200 bg-slate-100 p-1 shadow-sm;
-  @apply dark:border-slate-700 dark:bg-slate-950;
+  @apply mb-4 flex border-b border-slate-200;
+  @apply dark:border-slate-700;
 }
 
 .cert-tab-button {
-  @apply rounded-md px-3 py-1.5 text-xs font-semibold text-slate-600 transition-colors;
-  @apply hover:text-slate-950 focus:outline-none focus:ring-2 focus:ring-orange-500/40;
-  @apply dark:text-slate-300 dark:hover:text-slate-50;
+  @apply -mb-px border-b-2 border-transparent px-4 py-2 text-sm font-semibold text-slate-500 transition-colors;
+  @apply hover:border-slate-300 hover:text-slate-900 focus:outline-none focus:ring-2 focus:ring-orange-500/40;
+  @apply dark:text-slate-400 dark:hover:border-slate-500 dark:hover:text-slate-100;
 }
 
 .cert-tab-button.is-active {
-  @apply bg-white text-orange-700 shadow-sm;
-  @apply dark:bg-slate-800 dark:text-orange-300;
+  @apply border-orange-500 text-orange-700;
+  @apply dark:border-orange-400 dark:text-orange-300;
 }
 
 .cert-tab-panel {
@@ -393,7 +393,16 @@ a {
 }
 
 .details-stack {
+  @apply min-w-0 space-y-5;
+}
+
+.cert-detail-section {
   @apply min-w-0 space-y-3;
+}
+
+.detail-section-title {
+  @apply border-b border-orange-500/35 pb-1 text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-orange-600;
+  @apply dark:text-orange-400;
 }
 
 .advanced-decode {

--- a/internal/web/templates/results.html
+++ b/internal/web/templates/results.html
@@ -92,142 +92,22 @@
                     </div>
                     <div class="details-column" data-cert-tabs>
                         <div class="cert-tab-list" role="tablist" aria-label="Certificate decode view">
-                            <button type="button" class="cert-tab-button is-active" role="tab" aria-selected="true" data-cert-tab-button="basic" onclick="switchCertDecodeTab(this, 'basic')">Basic</button>
-                            <button type="button" class="cert-tab-button" role="tab" aria-selected="false" data-cert-tab-button="advanced" onclick="switchCertDecodeTab(this, 'advanced')">Advanced</button>
+                            <button type="button" class="cert-tab-button is-active" role="tab" aria-selected="true" data-cert-tab-button="overview" onclick="switchCertDecodeTab(this, 'overview')">Overview</button>
+                            <button type="button" class="cert-tab-button" role="tab" aria-selected="false" data-cert-tab-button="usage" onclick="switchCertDecodeTab(this, 'usage')">Usage</button>
+                            <button type="button" class="cert-tab-button" role="tab" aria-selected="false" data-cert-tab-button="extensions" onclick="switchCertDecodeTab(this, 'extensions')">Extensions</button>
+                            <button type="button" class="cert-tab-button" role="tab" aria-selected="false" data-cert-tab-button="raw" onclick="switchCertDecodeTab(this, 'raw')">Raw</button>
                         </div>
-                        <div class="cert-tab-panel" data-cert-tab-panel="basic">
-                        <div class="details-stack">
-                        <div class="detail-grid">
-                            <div class="detail-item">
-                                <div class="detail-label">Subject</div>
-                                <div class="detail-box">{{$gc.SubjectDN}}</div>
-                            </div>
-                            <div class="detail-item">
-                                <div class="detail-label">Issuer</div>
-                                <div class="detail-box">{{$gc.IssuerDN}}</div>
-                            </div>
+                        <div class="cert-tab-panel" data-cert-tab-panel="overview">
+                            {{template "cert-overview-details" $gc}}
                         </div>
-                        <div class="detail-grid">
-                            <div class="detail-item">
-                                <div class="detail-label">Not Before</div>
-                                <div class="detail-value {{if $gc.IsNotYetValid}}detail-future{{else}}detail-valid{{end}}">{{$gc.NotBeforeFormatted}}</div>
-                            </div>
-                            <div class="detail-item">
-                                <div class="detail-label">Not After</div>
-                                <div class="detail-value {{if $gc.IsExpired}}detail-expired{{else}}detail-valid{{end}}">{{$gc.NotAfterFormatted}}</div>
-                            </div>
+                        <div class="cert-tab-panel hidden" data-cert-tab-panel="usage">
+                            {{template "cert-usage-details" $gc}}
                         </div>
-                        <div class="detail-grid">
-                            <div class="detail-item">
-                                <div class="detail-label">Validity Period</div>
-                                <div class="detail-value detail-muted">{{$gc.ValidityPeriod}}</div>
-                            </div>
-                            <div class="detail-item">
-                                {{if $gc.IsExpired}}
-                                <div class="detail-label">Expired</div>
-                                <div class="detail-value detail-expired">{{$gc.ExpiresIn}} ago</div>
-                                {{else if $gc.IsNotYetValid}}
-                                <div class="detail-label">Starts In</div>
-                                <div class="detail-value detail-future">not yet valid</div>
-                                {{else}}
-                                <div class="detail-label">Expires In</div>
-                                <div class="detail-value detail-valid">{{$gc.ExpiresIn}}</div>
-                                {{end}}
-                            </div>
+                        <div class="cert-tab-panel hidden" data-cert-tab-panel="extensions">
+                            {{template "cert-extensions-details" $gc}}
                         </div>
-                        <div class="detail-grid">
-                            <div class="detail-item">
-                                <div class="detail-label">Serial Number</div>
-                                <div class="detail-box detail-box-mono hex-value">{{$gc.SerialNumber}}</div>
-                            </div>
-                            <div class="detail-item">
-                                <div class="detail-label">Signature Algorithm</div>
-                                <div class="detail-box">{{$gc.SignatureAlgorithm}}</div>
-                            </div>
-                        </div>
-                        {{if or $gc.IsCA $gc.HasPathLenConstraint}}
-                        <div class="detail-grid">
-                            <div class="detail-item">
-                                <div class="detail-label">Public Key</div>
-                                <div class="detail-box">{{$gc.PublicKeyInfo}}</div>
-                            </div>
-                            <div class="detail-item">
-                                <div class="detail-label">Basic Constraints</div>
-                                <div class="detail-box">CA: {{if $gc.IsCA}}Yes{{else}}No{{end}}{{if $gc.HasPathLenConstraint}}, Path Length: {{$gc.PathLenConstraint}}{{end}}</div>
-                            </div>
-                        </div>
-                        {{else}}
-                        <div class="detail-item">
-                            <div class="detail-label">Public Key</div>
-                            <div class="detail-box">{{$gc.PublicKeyInfo}}</div>
-                        </div>
-                        {{end}}
-                        {{if $gc.KeyUsage}}
-                        <div class="detail-item">
-                            <div class="detail-label">Key Usage</div>
-                            <div class="detail-box">{{$gc.KeyUsage}}</div>
-                        </div>
-                        {{end}}
-                        {{if $gc.ExtKeyUsage}}
-                        <div class="detail-item">
-                            <div class="detail-label">Extended Key Usage</div>
-                            <div class="detail-box">{{$gc.ExtKeyUsage}}</div>
-                        </div>
-                        {{end}}
-                        {{if $gc.CAIssuersURLs}}
-                        <div class="detail-item">
-                            <div class="detail-label">CA Issuers URL</div>
-                            <div class="detail-box detail-box-mono">
-                                <div class="ca-issuers-list">
-                                    {{range $gc.CAIssuersURLs}}
-                                    <a class="ca-issuers-link" href="{{.}}" rel="noopener noreferrer" target="_blank">{{.}}</a>
-                                    {{end}}
-                                </div>
-                            </div>
-                        </div>
-                        {{end}}
-                        {{if $gc.SANs}}
-                        <div class="detail-item">
-                            <div class="detail-label">Subject Alternative Names ({{len $gc.SANs}})</div>
-                            <div class="san-wrap">
-                                <div class="san-list">
-                                    {{range $gc.SANs}}
-                                    <span class="san-pill">{{.}}</span>
-                                    {{end}}
-                                </div>
-                            </div>
-                        </div>
-                        {{end}}
-                        <div class="detail-grid">
-                            {{if $gc.SKI}}
-                            <div class="detail-item">
-                                <div class="detail-label">Subject Key Identifier</div>
-                                <div class="detail-box detail-box-mono hex-value">{{$gc.SKI}}</div>
-                            </div>
-                            {{end}}
-                            {{if $gc.AKI}}
-                            <div class="detail-item">
-                                <div class="detail-label">Authority Key Identifier</div>
-                                <div class="detail-box detail-box-mono hex-value">{{$gc.AKI}}</div>
-                            </div>
-                            {{end}}
-                        </div>
-                        {{if $gc.SHA256Fingerprint}}
-                        <div class="detail-item">
-                            <div class="detail-label">SHA-256 Fingerprint</div>
-                            <div class="detail-box detail-box-mono hex-value">{{$gc.SHA256Fingerprint}}</div>
-                        </div>
-                        {{end}}
-                        {{if $gc.SHA1Fingerprint}}
-                        <div class="detail-item">
-                            <div class="detail-label">SHA-1 Fingerprint</div>
-                            <div class="detail-box detail-box-mono hex-value">{{$gc.SHA1Fingerprint}}</div>
-                        </div>
-                        {{end}}
-                        </div>
-                        </div>
-                        <div class="cert-tab-panel hidden" data-cert-tab-panel="advanced">
-                            <pre class="advanced-decode">{{$gc.AdvancedDecode}}</pre>
+                        <div class="cert-tab-panel hidden" data-cert-tab-panel="raw">
+                            {{template "cert-raw-details" $gc}}
                         </div>
                     </div>
                 </div>
@@ -268,151 +148,22 @@
                     </div>
                     <div class="details-column" data-cert-tabs>
                         <div class="cert-tab-list" role="tablist" aria-label="Certificate decode view">
-                            <button type="button" class="cert-tab-button is-active" role="tab" aria-selected="true" data-cert-tab-button="basic" onclick="switchCertDecodeTab(this, 'basic')">Basic</button>
-                            <button type="button" class="cert-tab-button" role="tab" aria-selected="false" data-cert-tab-button="advanced" onclick="switchCertDecodeTab(this, 'advanced')">Advanced</button>
+                            <button type="button" class="cert-tab-button is-active" role="tab" aria-selected="true" data-cert-tab-button="overview" onclick="switchCertDecodeTab(this, 'overview')">Overview</button>
+                            <button type="button" class="cert-tab-button" role="tab" aria-selected="false" data-cert-tab-button="usage" onclick="switchCertDecodeTab(this, 'usage')">Usage</button>
+                            <button type="button" class="cert-tab-button" role="tab" aria-selected="false" data-cert-tab-button="extensions" onclick="switchCertDecodeTab(this, 'extensions')">Extensions</button>
+                            <button type="button" class="cert-tab-button" role="tab" aria-selected="false" data-cert-tab-button="raw" onclick="switchCertDecodeTab(this, 'raw')">Raw</button>
                         </div>
-                        <div class="cert-tab-panel" data-cert-tab-panel="basic">
-                        <div class="details-stack">
-                        <div class="detail-grid">
-                            <div class="detail-item">
-                                <div class="detail-label">Subject</div>
-                                <div class="detail-box {{$cert.SubjectColor}}">{{$cert.SubjectDN}}</div>
-                            </div>
-                            <div class="detail-item">
-                                <div class="detail-label">Issuer</div>
-                                <div class="detail-box {{$cert.IssuerColor}}">{{$cert.IssuerDN}}</div>
-                            </div>
+                        <div class="cert-tab-panel" data-cert-tab-panel="overview">
+                            {{template "cert-overview-details" $cert}}
                         </div>
-
-                        <div class="detail-grid">
-                            <div class="detail-item">
-                                <div class="detail-label">Not Before</div>
-                                <div class="detail-value {{if $cert.IsNotYetValid}}detail-future{{else}}detail-valid{{end}}">{{$cert.NotBeforeFormatted}}</div>
-                            </div>
-                            <div class="detail-item">
-                                <div class="detail-label">Not After</div>
-                                <div class="detail-value {{if $cert.IsExpired}}detail-expired{{else}}detail-valid{{end}}">{{$cert.NotAfterFormatted}}</div>
-                            </div>
+                        <div class="cert-tab-panel hidden" data-cert-tab-panel="usage">
+                            {{template "cert-usage-details" $cert}}
                         </div>
-
-                        <div class="detail-grid">
-                            <div class="detail-item">
-                                <div class="detail-label">Validity Period</div>
-                                <div class="detail-value detail-muted">{{$cert.ValidityPeriod}}</div>
-                            </div>
-                            <div class="detail-item">
-                                {{if $cert.IsExpired}}
-                                <div class="detail-label">Expired</div>
-                                <div class="detail-value detail-expired">{{$cert.ExpiresIn}} ago</div>
-                                {{else if $cert.IsNotYetValid}}
-                                <div class="detail-label">Starts In</div>
-                                <div class="detail-value detail-future">not yet valid</div>
-                                {{else}}
-                                <div class="detail-label">Expires In</div>
-                                <div class="detail-value detail-valid">{{$cert.ExpiresIn}}</div>
-                                {{end}}
-                            </div>
+                        <div class="cert-tab-panel hidden" data-cert-tab-panel="extensions">
+                            {{template "cert-extensions-details" $cert}}
                         </div>
-
-                        <div class="detail-grid">
-                            <div class="detail-item">
-                                <div class="detail-label">Serial Number</div>
-                                <div class="detail-box detail-box-mono hex-value">{{$cert.SerialNumber}}</div>
-                            </div>
-                            <div class="detail-item">
-                                <div class="detail-label">Signature Algorithm</div>
-                                <div class="detail-box">{{$cert.SignatureAlgorithm}}</div>
-                            </div>
-                        </div>
-
-                        {{if or $cert.IsCA $cert.HasPathLenConstraint}}
-                        <div class="detail-grid">
-                            <div class="detail-item">
-                                <div class="detail-label">Public Key</div>
-                                <div class="detail-box">{{$cert.PublicKeyInfo}}</div>
-                            </div>
-                            <div class="detail-item">
-                                <div class="detail-label">Basic Constraints</div>
-                                <div class="detail-box">CA: {{if $cert.IsCA}}Yes{{else}}No{{end}}{{if $cert.HasPathLenConstraint}}, Path Length: {{$cert.PathLenConstraint}}{{end}}</div>
-                            </div>
-                        </div>
-                        {{else}}
-                        <div class="detail-item">
-                            <div class="detail-label">Public Key</div>
-                            <div class="detail-box">{{$cert.PublicKeyInfo}}</div>
-                        </div>
-                        {{end}}
-
-                        {{if $cert.KeyUsage}}
-                        <div class="detail-item">
-                            <div class="detail-label">Key Usage</div>
-                            <div class="detail-box">{{$cert.KeyUsage}}</div>
-                        </div>
-                        {{end}}
-
-                        {{if $cert.ExtKeyUsage}}
-                        <div class="detail-item">
-                            <div class="detail-label">Extended Key Usage</div>
-                            <div class="detail-box">{{$cert.ExtKeyUsage}}</div>
-                        </div>
-                        {{end}}
-                        {{if $cert.CAIssuersURLs}}
-                        <div class="detail-item">
-                            <div class="detail-label">CA Issuers URL</div>
-                            <div class="detail-box detail-box-mono">
-                                <div class="ca-issuers-list">
-                                    {{range $cert.CAIssuersURLs}}
-                                    <a class="ca-issuers-link" href="{{.}}" rel="noopener noreferrer" target="_blank">{{.}}</a>
-                                    {{end}}
-                                </div>
-                            </div>
-                        </div>
-                        {{end}}
-
-                        {{if $cert.SANs}}
-                        <div class="detail-item">
-                            <div class="detail-label">Subject Alternative Names ({{len $cert.SANs}})</div>
-                            <div class="san-wrap">
-                                <div class="san-list">
-                                    {{range $cert.SANs}}
-                                    <span class="san-pill">{{.}}</span>
-                                    {{end}}
-                                </div>
-                            </div>
-                        </div>
-                        {{end}}
-
-                        <div class="detail-grid">
-                            {{if $cert.SKI}}
-                            <div class="detail-item">
-                                <div class="detail-label">Subject Key Identifier</div>
-                                <div class="detail-box detail-box-mono hex-value">{{$cert.SKI}}</div>
-                            </div>
-                            {{end}}
-                            {{if $cert.AKI}}
-                            <div class="detail-item">
-                                <div class="detail-label">Authority Key Identifier</div>
-                                <div class="detail-box detail-box-mono hex-value">{{$cert.AKI}}</div>
-                            </div>
-                            {{end}}
-                        </div>
-
-                        {{if $cert.SHA256Fingerprint}}
-                        <div class="detail-item">
-                            <div class="detail-label">SHA-256 Fingerprint</div>
-                            <div class="detail-box detail-box-mono hex-value">{{$cert.SHA256Fingerprint}}</div>
-                        </div>
-                        {{end}}
-                        {{if $cert.SHA1Fingerprint}}
-                        <div class="detail-item">
-                            <div class="detail-label">SHA-1 Fingerprint</div>
-                            <div class="detail-box detail-box-mono hex-value">{{$cert.SHA1Fingerprint}}</div>
-                        </div>
-                        {{end}}
-                        </div>
-                        </div>
-                        <div class="cert-tab-panel hidden" data-cert-tab-panel="advanced">
-                            <pre class="advanced-decode">{{$cert.AdvancedDecode}}</pre>
+                        <div class="cert-tab-panel hidden" data-cert-tab-panel="raw">
+                            {{template "cert-raw-details" $cert}}
                         </div>
                     </div>
                 </div>
@@ -420,5 +171,304 @@
             {{end}}
         </div>
     </div>
+</div>
+{{end}}
+
+{{define "cert-overview-details"}}
+<div class="details-stack">
+    {{if or .SubjectDN .IssuerDN .SANs}}
+    <section class="cert-detail-section">
+        <h4 class="detail-section-title">Identity</h4>
+        <div class="detail-grid">
+            {{if .SubjectDN}}
+            <div class="detail-item">
+                <div class="detail-label">Subject</div>
+                <div class="detail-box {{.SubjectColor}}">{{.SubjectDN}}</div>
+            </div>
+            {{end}}
+            {{if .IssuerDN}}
+            <div class="detail-item">
+                <div class="detail-label">Issuer</div>
+                <div class="detail-box {{.IssuerColor}}">{{.IssuerDN}}</div>
+            </div>
+            {{end}}
+        </div>
+        {{if .SANs}}
+        <div class="detail-item">
+            <div class="detail-label">Subject Alternative Names ({{len .SANs}})</div>
+            <div class="san-wrap">
+                <div class="san-list">
+                    {{range .SANs}}
+                    <span class="san-pill">{{.}}</span>
+                    {{end}}
+                </div>
+            </div>
+        </div>
+        {{end}}
+    </section>
+    {{end}}
+
+    <section class="cert-detail-section">
+        <h4 class="detail-section-title">Validity</h4>
+        <div class="detail-grid">
+            <div class="detail-item">
+                <div class="detail-label">Not Before</div>
+                <div class="detail-value {{if .IsNotYetValid}}detail-future{{else}}detail-valid{{end}}">{{.NotBeforeFormatted}}</div>
+            </div>
+            <div class="detail-item">
+                <div class="detail-label">Not After</div>
+                <div class="detail-value {{if .IsExpired}}detail-expired{{else}}detail-valid{{end}}">{{.NotAfterFormatted}}</div>
+            </div>
+        </div>
+        <div class="detail-grid">
+            <div class="detail-item">
+                <div class="detail-label">Validity Period</div>
+                <div class="detail-value detail-muted">{{.ValidityPeriod}}</div>
+            </div>
+            <div class="detail-item">
+                {{if .IsExpired}}
+                <div class="detail-label">Expired</div>
+                <div class="detail-value detail-expired">{{.ExpiresIn}} ago</div>
+                {{else if .IsNotYetValid}}
+                <div class="detail-label">Starts In</div>
+                <div class="detail-value detail-future">not yet valid</div>
+                {{else}}
+                <div class="detail-label">Expires In</div>
+                <div class="detail-value detail-valid">{{.ExpiresIn}}</div>
+                {{end}}
+            </div>
+        </div>
+    </section>
+
+    {{if or .PublicKeyInfo .SignatureAlgorithm}}
+    <section class="cert-detail-section">
+        <h4 class="detail-section-title">Cryptography</h4>
+        <div class="detail-grid">
+            {{if .PublicKeyInfo}}
+            <div class="detail-item">
+                <div class="detail-label">Public Key</div>
+                <div class="detail-box">{{.PublicKeyInfo}}</div>
+            </div>
+            {{end}}
+            {{if .SignatureAlgorithm}}
+            <div class="detail-item">
+                <div class="detail-label">Signature Algorithm</div>
+                <div class="detail-box">{{.SignatureAlgorithm}}</div>
+            </div>
+            {{end}}
+        </div>
+    </section>
+    {{end}}
+
+    {{if or .SerialNumber .SHA256Fingerprint .SHA1Fingerprint}}
+    <section class="cert-detail-section">
+        <h4 class="detail-section-title">Identifiers</h4>
+        {{if .SerialNumber}}
+        <div class="detail-item">
+            <div class="detail-label">Serial Number</div>
+            <div class="detail-box detail-box-mono hex-value">{{.SerialNumber}}</div>
+        </div>
+        {{end}}
+        {{if .SHA256Fingerprint}}
+        <div class="detail-item">
+            <div class="detail-label">SHA-256 Fingerprint</div>
+            <div class="detail-box detail-box-mono hex-value">{{.SHA256Fingerprint}}</div>
+        </div>
+        {{end}}
+        {{if .SHA1Fingerprint}}
+        <div class="detail-item">
+            <div class="detail-label">SHA-1 Fingerprint</div>
+            <div class="detail-box detail-box-mono hex-value">{{.SHA1Fingerprint}}</div>
+        </div>
+        {{end}}
+    </section>
+    {{end}}
+</div>
+{{end}}
+
+{{define "cert-usage-details"}}
+<div class="details-stack">
+    {{if or .HasBasicConstraints .KeyUsage .ExtKeyUsage}}
+    <section class="cert-detail-section">
+        <h4 class="detail-section-title">Usage</h4>
+        {{if .HasBasicConstraints}}
+        <div class="detail-grid">
+            <div class="detail-item">
+                <div class="detail-label">CA</div>
+                <div class="detail-box">{{if .IsCA}}Yes{{else}}No{{end}}</div>
+            </div>
+            {{if .HasPathLenConstraint}}
+            <div class="detail-item">
+                <div class="detail-label">Path Length</div>
+                <div class="detail-box">{{.PathLenConstraint}}</div>
+            </div>
+            {{end}}
+        </div>
+        {{end}}
+        {{if .KeyUsage}}
+        <div class="detail-item">
+            <div class="detail-label">Key Usage</div>
+            <div class="detail-box">{{.KeyUsage}}</div>
+        </div>
+        {{end}}
+        {{if .ExtKeyUsage}}
+        <div class="detail-item">
+            <div class="detail-label">Extended Key Usage</div>
+            <div class="detail-box">{{.ExtKeyUsage}}</div>
+        </div>
+        {{end}}
+    </section>
+    {{else}}
+    <section class="cert-detail-section">
+        <h4 class="detail-section-title">Usage</h4>
+        <div class="detail-box detail-muted">No decoded usage extensions available.</div>
+    </section>
+    {{end}}
+</div>
+{{end}}
+
+{{define "cert-extensions-details"}}
+<div class="details-stack">
+    {{if or .CAIssuersURLs .OCSPURLs}}
+    <section class="cert-detail-section">
+        <h4 class="detail-section-title">Authority Information Access</h4>
+        {{if .CAIssuersURLs}}
+        <div class="detail-item">
+            <div class="detail-label">CA Issuers URL</div>
+            <div class="detail-box detail-box-mono">
+                <div class="ca-issuers-list">
+                    {{range .CAIssuersURLs}}
+                    <span>{{.}}</span>
+                    {{end}}
+                </div>
+            </div>
+        </div>
+        {{end}}
+        {{if .OCSPURLs}}
+        <div class="detail-item">
+            <div class="detail-label">OCSP URL</div>
+            <div class="detail-box detail-box-mono">
+                <div class="ca-issuers-list">
+                    {{range .OCSPURLs}}
+                    <span>{{.}}</span>
+                    {{end}}
+                </div>
+            </div>
+        </div>
+        {{end}}
+    </section>
+    {{end}}
+
+    {{if or .SKI .AKI}}
+    <section class="cert-detail-section">
+        <h4 class="detail-section-title">Key Identifiers</h4>
+        {{if or .SKI .AKI}}
+        <div class="detail-grid">
+            {{if .SKI}}
+            <div class="detail-item">
+                <div class="detail-label">Subject Key Identifier</div>
+                <div class="detail-box detail-box-mono hex-value">{{.SKI}}</div>
+            </div>
+            {{end}}
+            {{if .AKI}}
+            <div class="detail-item">
+                <div class="detail-label">Authority Key Identifier</div>
+                <div class="detail-box detail-box-mono hex-value">{{.AKI}}</div>
+            </div>
+            {{end}}
+        </div>
+        {{end}}
+    </section>
+    {{end}}
+
+    {{if .NameConstraints}}
+    <section class="cert-detail-section">
+        <h4 class="detail-section-title">Name Constraints</h4>
+        <div class="detail-item">
+            <div class="detail-label">Name Constraints</div>
+            <div class="san-wrap">
+                <div class="san-list">
+                    {{range .NameConstraints}}
+                    <span class="san-pill">{{.}}</span>
+                    {{end}}
+                </div>
+            </div>
+        </div>
+    </section>
+    {{end}}
+
+    {{if .CRLDistributionPoints}}
+    <section class="cert-detail-section">
+        <h4 class="detail-section-title">Revocation</h4>
+        <div class="detail-item">
+            <div class="detail-label">CRL Distribution Points</div>
+            <div class="detail-box detail-box-mono">
+                <div class="ca-issuers-list">
+                    {{range .CRLDistributionPoints}}
+                    <span>{{.}}</span>
+                    {{end}}
+                </div>
+            </div>
+        </div>
+    </section>
+    {{end}}
+
+    {{if or .CertificatePolicies .PolicyConstraints .PolicyMappings}}
+    <section class="cert-detail-section">
+        <h4 class="detail-section-title">Policies</h4>
+        {{if .CertificatePolicies}}
+        <div class="detail-item">
+            <div class="detail-label">Certificate Policies</div>
+            <div class="detail-box detail-box-mono">
+                <div class="ca-issuers-list">
+                    {{range .CertificatePolicies}}
+                    <span>{{.}}</span>
+                    {{end}}
+                </div>
+            </div>
+        </div>
+        {{end}}
+        {{if .PolicyConstraints}}
+        <div class="detail-item">
+            <div class="detail-label">Policy Constraints</div>
+            <div class="detail-box detail-box-mono">
+                <div class="ca-issuers-list">
+                    {{range .PolicyConstraints}}
+                    <span>{{.}}</span>
+                    {{end}}
+                </div>
+            </div>
+        </div>
+        {{end}}
+        {{if .PolicyMappings}}
+        <div class="detail-item">
+            <div class="detail-label">Policy Mappings</div>
+            <div class="detail-box detail-box-mono">
+                <div class="ca-issuers-list">
+                    {{range .PolicyMappings}}
+                    <span>{{.}}</span>
+                    {{end}}
+                </div>
+            </div>
+        </div>
+        {{end}}
+    </section>
+    {{end}}
+
+    {{if not (or .CAIssuersURLs .OCSPURLs .SKI .AKI .NameConstraints .CRLDistributionPoints .CertificatePolicies .PolicyConstraints .PolicyMappings)}}
+    <section class="cert-detail-section">
+        <h4 class="detail-section-title">Extensions</h4>
+        <div class="detail-box detail-muted">No decoded extension details available.</div>
+    </section>
+    {{end}}
+</div>
+{{end}}
+
+{{define "cert-raw-details"}}
+<div class="details-stack">
+    <section class="cert-detail-section">
+        <h4 class="detail-section-title">Raw Decode</h4>
+        <pre class="advanced-decode">{{.AdvancedDecode}}</pre>
+    </section>
 </div>
 {{end}}

--- a/internal/web/types.go
+++ b/internal/web/types.go
@@ -58,38 +58,45 @@ type CrawlResultInput struct {
 
 // CertViewData is the view model for certificate display.
 type CertViewData struct {
-	HashHex              string
-	Position             int
-	PEM                  string
-	SubjectCN            string
-	SubjectDN            string
-	IssuerDN             string
-	NotBeforeFormatted   string
-	NotAfterFormatted    string
-	NotBefore            time.Time
-	NotAfter             time.Time
-	IsExpired            bool
-	IsNotYetValid        bool
-	ValidityDays         int
-	ValidityPeriod       string
-	ExpiresIn            string
-	IsCA                 bool
-	IsSelfSigned         bool
-	HasPathLenConstraint bool
-	PathLenConstraint    int
-	SerialNumber         string
-	SignatureAlgorithm   string
-	PublicKeyInfo        string
-	SANs                 []string
-	CAIssuersURLs        []string
-	KeyUsage             string
-	ExtKeyUsage          string
-	SKI                  string
-	AKI                  string
-	SHA1Fingerprint      string
-	SHA256Fingerprint    string
-	AdvancedDecode       string
-	PossibleIssuers      []string
+	HashHex               string
+	Position              int
+	PEM                   string
+	SubjectCN             string
+	SubjectDN             string
+	IssuerDN              string
+	NotBeforeFormatted    string
+	NotAfterFormatted     string
+	NotBefore             time.Time
+	NotAfter              time.Time
+	IsExpired             bool
+	IsNotYetValid         bool
+	ValidityDays          int
+	ValidityPeriod        string
+	ExpiresIn             string
+	IsCA                  bool
+	HasBasicConstraints   bool
+	IsSelfSigned          bool
+	HasPathLenConstraint  bool
+	PathLenConstraint     int
+	SerialNumber          string
+	SignatureAlgorithm    string
+	PublicKeyInfo         string
+	SANs                  []string
+	NameConstraints       []string
+	CAIssuersURLs         []string
+	OCSPURLs              []string
+	CRLDistributionPoints []string
+	CertificatePolicies   []string
+	PolicyConstraints     []string
+	PolicyMappings        []string
+	KeyUsage              string
+	ExtKeyUsage           string
+	SKI                   string
+	AKI                   string
+	SHA1Fingerprint       string
+	SHA256Fingerprint     string
+	AdvancedDecode        string
+	PossibleIssuers       []string
 	// CertLabel is the human-readable label for this certificate's role in the chain
 	CertLabel string
 	// SubjectColor is the CSS color class for the subject DN
@@ -161,7 +168,8 @@ func populateFromParsedCert(view *CertViewData, cert *x509.Certificate) {
 	view.IssuerDN = cert.Issuer.String()
 	view.IsCA = cert.IsCA
 	view.IsSelfSigned = isSelfSigned(cert)
-	view.HasPathLenConstraint = cert.BasicConstraintsValid && cert.MaxPathLen >= 0
+	view.HasBasicConstraints = cert.BasicConstraintsValid
+	view.HasPathLenConstraint = cert.BasicConstraintsValid && (cert.MaxPathLen > 0 || cert.MaxPathLenZero)
 	view.PathLenConstraint = cert.MaxPathLen
 	view.SerialNumber = formatSerialNumber(cert.SerialNumber.Bytes())
 	view.SignatureAlgorithm = cert.SignatureAlgorithm.String()
@@ -181,6 +189,12 @@ func populateFromParsedCert(view *CertViewData, cert *x509.Certificate) {
 		}
 	}
 	view.CAIssuersURLs = append(view.CAIssuersURLs, cert.IssuingCertificateURL...)
+	view.OCSPURLs = append(view.OCSPURLs, cert.OCSPServer...)
+	view.CRLDistributionPoints = append(view.CRLDistributionPoints, cert.CRLDistributionPoints...)
+	view.NameConstraints = formatNameConstraints(cert)
+	view.CertificatePolicies = formatCertificatePolicies(cert)
+	view.PolicyConstraints = formatPolicyConstraints(cert)
+	view.PolicyMappings = formatPolicyMappings(cert)
 
 	// Key Usage
 	view.KeyUsage = formatKeyUsage(cert.KeyUsage)
@@ -222,7 +236,7 @@ func formatAdvancedCertificate(cert *x509.Certificate) string {
 
 	writeAdvancedLine(&b, 2, "X509v3 extensions:")
 	for _, ext := range cert.Extensions {
-		writeAdvancedExtension(&b, ext)
+		writeAdvancedExtension(&b, ext, cert)
 	}
 	if len(cert.UnhandledCriticalExtensions) > 0 {
 		writeAdvancedLine(&b, 2, "Unhandled Critical Extensions:")
@@ -257,7 +271,7 @@ func writeWrappedHex(b *strings.Builder, indent int, data []byte, perLine int) {
 	}
 }
 
-func writeAdvancedExtension(b *strings.Builder, ext pkix.Extension) {
+func writeAdvancedExtension(b *strings.Builder, ext pkix.Extension, cert *x509.Certificate) {
 	name := extensionName(ext.Id)
 	critical := ""
 	if ext.Critical {
@@ -265,7 +279,7 @@ func writeAdvancedExtension(b *strings.Builder, ext pkix.Extension) {
 	}
 	writeAdvancedLine(b, 3, "%s%s:", name, critical)
 
-	if formatted, ok := formatKnownExtension(ext); ok {
+	if formatted, ok := formatKnownExtension(ext, cert); ok {
 		for _, line := range strings.Split(formatted, "\n") {
 			writeAdvancedLine(b, 4, "%s", line)
 		}
@@ -295,19 +309,62 @@ func extensionName(oid asn1.ObjectIdentifier) string {
 	return oid.String()
 }
 
-func formatKnownExtension(ext pkix.Extension) (string, bool) {
+func formatKnownExtension(ext pkix.Extension, cert *x509.Certificate) (string, bool) {
 	switch ext.Id.String() {
-	case "2.5.29.14", "2.5.29.35":
-		var keyID []byte
-		if _, err := asn1.Unmarshal(ext.Value, &keyID); err == nil && len(keyID) > 0 {
-			return formatHexBytes(keyID), true
+	case "2.5.29.14":
+		if len(cert.SubjectKeyId) > 0 {
+			return formatHexBytes(cert.SubjectKeyId), true
+		}
+	case "2.5.29.35":
+		if len(cert.AuthorityKeyId) > 0 {
+			return formatHexBytes(cert.AuthorityKeyId), true
 		}
 	case "2.5.29.15":
+		if usage := formatKeyUsage(cert.KeyUsage); usage != "" {
+			return usage, true
+		}
 		return formatBitStringExtension(ext.Value), true
+	case "2.5.29.17":
+		if san := formatSubjectAlternativeNames(cert); san != "" {
+			return san, true
+		}
 	case "2.5.29.19":
+		if cert.BasicConstraintsValid {
+			return formatParsedBasicConstraints(cert), true
+		}
 		return formatBasicConstraintsExtension(ext.Value), true
+	case "2.5.29.31":
+		if len(cert.CRLDistributionPoints) > 0 {
+			return strings.Join(cert.CRLDistributionPoints, "\n"), true
+		}
+	case "2.5.29.32":
+		if policies := formatCertificatePolicies(cert); len(policies) > 0 {
+			return strings.Join(policies, "\n"), true
+		}
+	case "2.5.29.37":
+		if usage := formatExtKeyUsage(cert.ExtKeyUsage); usage != "" {
+			return usage, true
+		}
+	case "1.3.6.1.5.5.7.1.1":
+		var entries []string
+		for _, url := range cert.IssuingCertificateURL {
+			entries = append(entries, "CA Issuers - URI:"+url)
+		}
+		for _, url := range cert.OCSPServer {
+			entries = append(entries, "OCSP - URI:"+url)
+		}
+		if len(entries) > 0 {
+			return strings.Join(entries, "\n"), true
+		}
 	}
 	return "", false
+}
+
+func formatParsedBasicConstraints(cert *x509.Certificate) string {
+	if cert.MaxPathLen > 0 || cert.MaxPathLenZero {
+		return fmt.Sprintf("CA:%t, pathlen:%d", cert.IsCA, cert.MaxPathLen)
+	}
+	return fmt.Sprintf("CA:%t", cert.IsCA)
 }
 
 func formatBitStringExtension(value []byte) string {
@@ -450,6 +507,70 @@ func formatExtKeyUsage(eku []x509.ExtKeyUsage) string {
 	return strings.Join(usages, ", ")
 }
 
+func formatNameConstraints(cert *x509.Certificate) []string {
+	var constraints []string
+	appendValues := func(label string, values []string) {
+		for _, value := range values {
+			constraints = append(constraints, label+": "+value)
+		}
+	}
+	appendValues("Permitted DNS", cert.PermittedDNSDomains)
+	appendValues("Excluded DNS", cert.ExcludedDNSDomains)
+	appendValues("Permitted Email", cert.PermittedEmailAddresses)
+	appendValues("Excluded Email", cert.ExcludedEmailAddresses)
+	appendValues("Permitted URI Domain", cert.PermittedURIDomains)
+	appendValues("Excluded URI Domain", cert.ExcludedURIDomains)
+	for _, value := range cert.PermittedIPRanges {
+		constraints = append(constraints, "Permitted IP: "+value.String())
+	}
+	for _, value := range cert.ExcludedIPRanges {
+		constraints = append(constraints, "Excluded IP: "+value.String())
+	}
+	return constraints
+}
+
+func formatCertificatePolicies(cert *x509.Certificate) []string {
+	var policies []string
+	seen := make(map[string]struct{})
+	for _, policy := range cert.Policies {
+		value := policy.String()
+		if _, ok := seen[value]; !ok {
+			policies = append(policies, value)
+			seen[value] = struct{}{}
+		}
+	}
+	for _, policy := range cert.PolicyIdentifiers {
+		value := policy.String()
+		if _, ok := seen[value]; !ok {
+			policies = append(policies, value)
+			seen[value] = struct{}{}
+		}
+	}
+	return policies
+}
+
+func formatPolicyConstraints(cert *x509.Certificate) []string {
+	var constraints []string
+	if cert.RequireExplicitPolicy > 0 || cert.RequireExplicitPolicyZero {
+		constraints = append(constraints, fmt.Sprintf("Require Explicit Policy: %d", cert.RequireExplicitPolicy))
+	}
+	if cert.InhibitPolicyMapping > 0 || cert.InhibitPolicyMappingZero {
+		constraints = append(constraints, fmt.Sprintf("Inhibit Policy Mapping: %d", cert.InhibitPolicyMapping))
+	}
+	if cert.InhibitAnyPolicy > 0 || cert.InhibitAnyPolicyZero {
+		constraints = append(constraints, fmt.Sprintf("Inhibit anyPolicy: %d", cert.InhibitAnyPolicy))
+	}
+	return constraints
+}
+
+func formatPolicyMappings(cert *x509.Certificate) []string {
+	mappings := make([]string, 0, len(cert.PolicyMappings))
+	for _, mapping := range cert.PolicyMappings {
+		mappings = append(mappings, mapping.IssuerDomainPolicy.String()+" -> "+mapping.SubjectDomainPolicy.String())
+	}
+	return mappings
+}
+
 // formatCertDuration formats a duration for certificate context using an
 // appropriate combination of years, months, and days.
 func formatCertDuration(d time.Duration) string {
@@ -507,9 +628,9 @@ func parsePEM(pem string) (*x509.Certificate, error) {
 	return info.Parsed, nil
 }
 
-// isSelfSigned checks if a certificate is self-signed by comparing Subject and Issuer.
+// isSelfSigned checks whether a certificate is signed by its own key.
 func isSelfSigned(cert *x509.Certificate) bool {
-	return cert.Subject.String() == cert.Issuer.String()
+	return cert.CheckSignatureFrom(cert) == nil
 }
 
 // chainColorPalette defines the colors used for matching subject/issuer pairs.


### PR DESCRIPTION
## Summary
- reorganize certificate detail views into Overview, Usage, Extensions, and Raw tabs
- move extension-backed fields out of Overview and remove the derived Certificate Role field
- improve raw extension decoding for common X.509 extensions

## Validation
- go test ./...