### PR TITLE
[codex] Fix Mermaid certificate role colors

### DIFF
--- a/internal/web/chain_graph.go
+++ b/internal/web/chain_graph.go
@@ -25,6 +25,8 @@ type ChainGraphNode struct {
 	InChain bool
 	// IsSelfSigned indicates the certificate's own public key validates its signature.
 	IsSelfSigned bool
+	// IsCA indicates the certificate has CA basic constraints enabled.
+	IsCA bool
 	// IsMissing indicates the issuer was identified but no matching certificate was found.
 	IsMissing bool
 	// IsExpired indicates the certificate is expired as of graph build time.
@@ -99,8 +101,8 @@ func buildChainGraph(ctx context.Context, repo Repository, chainCerts []*Certifi
 		builder.chainSet[hashHex] = true
 	}
 
-	// Build the tree starting from the leaf
-	root := builder.buildNode(chainCerts[0], make(map[string]bool), 0)
+	// Build the tree starting from the end-entity certificate when present.
+	root := builder.buildNode(selectGraphStartCert(chainCerts), make(map[string]bool), 0)
 
 	if root == nil {
 		return nil
@@ -121,7 +123,6 @@ func buildChainGraph(ctx context.Context, repo Repository, chainCerts []*Certifi
 type mermaidGraphBuilder struct {
 	nextNodeID      int
 	nextMissingID   int
-	leafHash        string
 	nodeIDByHash    map[string]string
 	nodeToCertIndex map[string]int
 	inChainNodeSet  map[string]bool
@@ -138,7 +139,6 @@ func buildMermaidDiagram(root *ChainGraphNode) (string, map[string]int, ChainGra
 	}
 
 	b := &mermaidGraphBuilder{
-		leafHash:        root.HashHex,
 		nodeIDByHash:    make(map[string]string),
 		nodeToCertIndex: make(map[string]int),
 		inChainNodeSet:  make(map[string]bool),
@@ -206,12 +206,12 @@ func (b *mermaidGraphBuilder) classifyNode(node *ChainGraphNode) string {
 	switch {
 	case node.IsMissing:
 		return "missing"
-	case node.HashHex == b.leafHash:
-		return "leaf"
 	case node.IsSelfSigned:
 		return "root"
-	default:
+	case node.IsCA:
 		return "intermediate"
+	default:
+		return "leaf"
 	}
 }
 
@@ -322,6 +322,7 @@ func (b *chainGraphBuilder) buildNode(cert *CertificateResult, visited map[strin
 		IssuerDN:     certIssuerDN(cert),
 		InChain:      b.chainSet[hashHex],
 		IsSelfSigned: selfSigned,
+		IsCA:         isCA(cert),
 		IsExpired:    isExpiredAt(cert, time.Now()),
 		CertIndex:    certIdx,
 	}
@@ -440,6 +441,23 @@ func isSignatureSelfSigned(cert *CertificateResult) bool {
 	return err == nil
 }
 
+func selectGraphStartCert(certs []*CertificateResult) *CertificateResult {
+	if len(certs) == 0 {
+		return nil
+	}
+	for _, cert := range certs {
+		if cert != nil && !isCA(cert) {
+			return cert
+		}
+	}
+	for _, cert := range certs {
+		if cert != nil && !isSignatureSelfSigned(cert) {
+			return cert
+		}
+	}
+	return certs[0]
+}
+
 // certSubjectDN extracts the subject DN from a CertificateResult.
 func certSubjectDN(cert *CertificateResult) string {
 	if cert.Parsed != nil {
@@ -467,4 +485,14 @@ func isExpiredAt(cert *CertificateResult, now time.Time) bool {
 		return false
 	}
 	return now.After(cert.NotAfter)
+}
+
+func isCA(cert *CertificateResult) bool {
+	if cert == nil {
+		return false
+	}
+	if cert.Parsed != nil {
+		return cert.Parsed.IsCA
+	}
+	return false
 }

--- a/internal/web/chain_graph_test.go
+++ b/internal/web/chain_graph_test.go
@@ -327,6 +327,97 @@ func TestBuildChainGraph_MermaidStylingAndGrouping(t *testing.T) {
 	}
 }
 
+func TestBuildChainGraph_MermaidClassifiesUploadedIntermediateByCertificateRole(t *testing.T) {
+	root := generateSelfSignedRoot(t, "Manual Root CA")
+	inter := generateSignedIntermediate(t, "Manual Intermediate CA", root)
+
+	repo := newSKILookupRepo()
+	repo.registerCert(root)
+
+	graph := buildChainGraph(context.Background(), repo, []*CertificateResult{inter.result}, ChainGraphFilters{ShowNonChainCerts: true, ShowExpired: true})
+	if graph == nil {
+		t.Fatal("expected non-nil graph")
+	}
+
+	diagram := graph.MermaidDiagram
+	if strings.Contains(diagram, "class n0 leaf;") {
+		t.Fatalf("uploaded intermediate was classified as server certificate:\n%s", diagram)
+	}
+	if !strings.Contains(diagram, "class n0 intermediate;") {
+		t.Fatalf("expected uploaded intermediate to use intermediate class:\n%s", diagram)
+	}
+	if !strings.Contains(diagram, "class n1 root;") {
+		t.Fatalf("expected discovered self-signed issuer to use root class:\n%s", diagram)
+	}
+	if graph.Legend.HasServerCertificate {
+		t.Error("did not expect server certificate legend item")
+	}
+	if !graph.Legend.HasIntermediateCA {
+		t.Error("expected intermediate CA legend item")
+	}
+	if !graph.Legend.HasRootCA {
+		t.Error("expected root CA legend item")
+	}
+}
+
+func TestBuildChainGraph_MermaidClassifiesUploadedRootByCertificateRole(t *testing.T) {
+	root := generateSelfSignedRoot(t, "Manual Root CA")
+
+	repo := newSKILookupRepo()
+
+	graph := buildChainGraph(context.Background(), repo, []*CertificateResult{root.result}, ChainGraphFilters{ShowNonChainCerts: true, ShowExpired: true})
+	if graph == nil {
+		t.Fatal("expected non-nil graph")
+	}
+
+	diagram := graph.MermaidDiagram
+	if strings.Contains(diagram, "class n0 leaf;") {
+		t.Fatalf("uploaded root was classified as server certificate:\n%s", diagram)
+	}
+	if !strings.Contains(diagram, "class n0 root;") {
+		t.Fatalf("expected uploaded root to use root class:\n%s", diagram)
+	}
+	if graph.Legend.HasServerCertificate {
+		t.Error("did not expect server certificate legend item")
+	}
+	if graph.Legend.HasIntermediateCA {
+		t.Error("did not expect intermediate CA legend item")
+	}
+	if !graph.Legend.HasRootCA {
+		t.Error("expected root CA legend item")
+	}
+}
+
+func TestBuildChainGraph_MermaidUsesEndEntityWhenChainOrderIsWrong(t *testing.T) {
+	root := generateSelfSignedRoot(t, "Misordered Root CA")
+	inter := generateSignedIntermediate(t, "Misordered Intermediate CA", root)
+	leaf := generateLeafCert(t, "misordered.example.com", inter)
+
+	repo := newSKILookupRepo()
+	repo.registerCert(root)
+	repo.registerCert(inter)
+
+	chainCerts := []*CertificateResult{inter.result, leaf.result, root.result}
+	graph := buildChainGraph(context.Background(), repo, chainCerts, ChainGraphFilters{ShowNonChainCerts: true, ShowExpired: true})
+	if graph == nil {
+		t.Fatal("expected non-nil graph")
+	}
+	if graph.Root.SubjectCN != "misordered.example.com" {
+		t.Fatalf("expected graph to start from non-CA certificate, got %q", graph.Root.SubjectCN)
+	}
+
+	diagram := graph.MermaidDiagram
+	if !strings.Contains(diagram, "class n0 leaf;") {
+		t.Fatalf("expected end-entity certificate to use server class:\n%s", diagram)
+	}
+	if !strings.Contains(diagram, "class n1 intermediate;") {
+		t.Fatalf("expected issuer CA to use intermediate class:\n%s", diagram)
+	}
+	if !strings.Contains(diagram, "class n2 root;") {
+		t.Fatalf("expected self-signed issuer to use root class:\n%s", diagram)
+	}
+}
+
 func TestBuildChainGraph_OutOfChainRoot(t *testing.T) {
 	// Scenario: chain has only [leaf, intermediate], root is fetched from DB.
 	root := generateSelfSignedRoot(t, "Out-Of-Chain Root CA")


### PR DESCRIPTION
## Summary
- classify Mermaid certificate nodes by certificate properties instead of chain position
- start trust path graphs from the first end-entity certificate when a chain is misordered
- add regression tests for uploaded intermediate/root certificates and misordered chains

## Validation
- go test ./...