### PR TITLE
Add pan/zoom controls to trust path diagram

### DIFF
--- a/internal/web/static/css/style.css
+++ b/internal/web/static/css/style.css
@@ -37,6 +37,7 @@
     --color-sky-100: oklch(95.1% 0.026 236.824);
     --color-sky-300: oklch(82.8% 0.111 230.318);
     --color-sky-400: oklch(74.6% 0.16 232.661);
+    --color-sky-500: oklch(68.5% 0.169 237.323);
     --color-sky-700: oklch(50% 0.134 242.749);
     --color-sky-900: oklch(39.1% 0.09 240.876);
     --color-blue-50: oklch(97% 0.014 254.604);
@@ -1436,13 +1437,11 @@ a {
   }
 }
 .graph-scroll {
-  overflow-x: auto;
   padding-block: calc(var(--spacing) * 3);
 }
 .graph-center {
-  display: flex;
+  display: block;
   min-width: 100%;
-  justify-content: center;
 }
 .selected-heading {
   margin-top: calc(var(--spacing) * 4);
@@ -2036,7 +2035,9 @@ a {
 }
 .graph-download-row {
   display: flex;
-  justify-content: flex-end;
+  align-items: center;
+  justify-content: space-between;
+  gap: calc(var(--spacing) * 3);
   padding-top: calc(var(--spacing) * 1);
 }
 .btn-graph-download {
@@ -2092,18 +2093,87 @@ a {
     }
   }
 }
+.graph-controls {
+  display: flex;
+  align-items: center;
+  gap: calc(var(--spacing) * 1);
+}
+.btn-graph-control {
+  display: inline-flex;
+  height: calc(var(--spacing) * 8);
+  width: calc(var(--spacing) * 8);
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-lg);
+  border-style: var(--tw-border-style);
+  border-width: 1px;
+  border-color: var(--color-slate-300);
+  background-color: var(--color-white);
+  color: var(--color-slate-600);
+  transition-property: color, background-color, border-color, outline-color, text-decoration-color, fill, stroke, --tw-gradient-from, --tw-gradient-via, --tw-gradient-to;
+  transition-timing-function: var(--tw-ease, var(--default-transition-timing-function));
+  transition-duration: var(--tw-duration, var(--default-transition-duration));
+  &:hover {
+    @media (hover: hover) {
+      background-color: var(--color-slate-100);
+    }
+  }
+  &:hover {
+    @media (hover: hover) {
+      color: var(--color-slate-900);
+    }
+  }
+  &:focus-visible {
+    outline-style: var(--tw-outline-style);
+    outline-width: 1px;
+  }
+  &:focus-visible {
+    outline-style: var(--tw-outline-style);
+    outline-width: 2px;
+  }
+  &:focus-visible {
+    outline-offset: 2px;
+  }
+  &:focus-visible {
+    outline-color: var(--color-sky-500);
+  }
+  &:where(.dark, .dark *) {
+    border-color: var(--color-slate-600);
+  }
+  &:where(.dark, .dark *) {
+    background-color: var(--color-slate-800);
+  }
+  &:where(.dark, .dark *) {
+    color: var(--color-slate-300);
+  }
+  &:where(.dark, .dark *) {
+    &:hover {
+      @media (hover: hover) {
+        background-color: var(--color-slate-700);
+      }
+    }
+  }
+  &:where(.dark, .dark *) {
+    &:hover {
+      @media (hover: hover) {
+        color: var(--color-slate-100);
+      }
+    }
+  }
+}
 .trust-path-mermaid {
-  width: min(100%, 56rem);
-  margin-left: auto;
-  margin-right: auto;
+  width: 100%;
 }
 .trust-path-mermaid svg {
   display: block;
-  width: 100%;
-  max-width: 100%;
-  height: auto;
-  margin-left: auto;
-  margin-right: auto;
+  width: 100% !important;
+  max-width: 100% !important;
+  height: clamp(24rem, 54vh, 38rem) !important;
+  cursor: grab;
+  user-select: none;
+}
+.trust-path-mermaid svg.is-panning {
+  cursor: grabbing;
 }
 .trust-path-mermaid .mermaid {
   display: block;
@@ -2424,6 +2494,11 @@ a {
   syntax: "*";
   inherits: false;
 }
+@property --tw-outline-style {
+  syntax: "*";
+  inherits: false;
+  initial-value: solid;
+}
 @keyframes spin {
   to {
     transform: rotate(360deg);
@@ -2488,6 +2563,7 @@ a {
       --tw-ring-offset-color: #fff;
       --tw-ring-offset-shadow: 0 0 #0000;
       --tw-leading: initial;
+      --tw-outline-style: solid;
     }
   }
 }

--- a/internal/web/static/js/script.js
+++ b/internal/web/static/js/script.js
@@ -60,9 +60,261 @@ function renderTrustPathMermaid(scope) {
     if (!diagrams.length) {
         return;
     }
-    mermaid.run({ nodes: Array.from(diagrams) }).catch(function (err) {
+    mermaid.run({ nodes: Array.from(diagrams) }).then(function () {
+        initializeTrustPathGraphControls(root);
+    }).catch(function (err) {
         console.error("failed to render mermaid trust-path diagram", err);
     });
+}
+
+function parseSVGViewBox(svg) {
+    var attr = svg.getAttribute("viewBox");
+    if (!attr) {
+        return null;
+    }
+    var parts = attr.trim().split(/[\s,]+/).map(Number);
+    if (parts.length !== 4 || parts.some(function (part) { return !Number.isFinite(part); })) {
+        return null;
+    }
+    return {
+        x: parts[0],
+        y: parts[1],
+        width: parts[2],
+        height: parts[3],
+    };
+}
+
+function getSVGViewBox(svg) {
+    var existing = parseSVGViewBox(svg);
+    if (existing) {
+        return existing;
+    }
+
+    var box = svg.getBBox ? svg.getBBox() : null;
+    if (box && box.width > 0 && box.height > 0) {
+        return {
+            x: box.x,
+            y: box.y,
+            width: box.width,
+            height: box.height,
+        };
+    }
+
+    return { x: 0, y: 0, width: 800, height: 600 };
+}
+
+function setSVGViewBox(svg, viewBox) {
+    svg.setAttribute("viewBox", [
+        viewBox.x,
+        viewBox.y,
+        viewBox.width,
+        viewBox.height,
+    ].join(" "));
+}
+
+function fitViewBoxToSVGAspect(svg, viewBox) {
+    var rect = svg.getBoundingClientRect();
+    if (!rect.width || !rect.height || !viewBox.width || !viewBox.height) {
+        return viewBox;
+    }
+
+    var svgRatio = rect.width / rect.height;
+    var viewBoxRatio = viewBox.width / viewBox.height;
+    if (!Number.isFinite(svgRatio) || !Number.isFinite(viewBoxRatio) || svgRatio <= 0 || viewBoxRatio <= 0) {
+        return viewBox;
+    }
+
+    if (svgRatio > viewBoxRatio) {
+        var expandedWidth = viewBox.height * svgRatio;
+        return {
+            x: viewBox.x - (expandedWidth - viewBox.width) / 2,
+            y: viewBox.y,
+            width: expandedWidth,
+            height: viewBox.height,
+        };
+    }
+
+    var expandedHeight = viewBox.width / svgRatio;
+    return {
+        x: viewBox.x,
+        y: viewBox.y - (expandedHeight - viewBox.height) / 2,
+        width: viewBox.width,
+        height: expandedHeight,
+    };
+}
+
+function getTrustPathGraphState(svg) {
+    if (!svg.__trustPathPanZoom) {
+        var initial = fitViewBoxToSVGAspect(svg, getSVGViewBox(svg));
+        svg.__trustPathPanZoom = {
+            initial: Object.assign({}, initial),
+            current: Object.assign({}, initial),
+        };
+        setSVGViewBox(svg, initial);
+    }
+    return svg.__trustPathPanZoom;
+}
+
+function clampTrustPathViewBox(svg, next) {
+    var state = getTrustPathGraphState(svg);
+    var minWidth = state.initial.width / 8;
+    var maxWidth = state.initial.width * 2.5;
+    var width = Math.max(minWidth, Math.min(maxWidth, next.width));
+    var height = width * (state.initial.height / state.initial.width);
+    return {
+        x: next.x,
+        y: next.y,
+        width: width,
+        height: height,
+    };
+}
+
+function zoomTrustPathGraph(svg, factor, clientX, clientY) {
+    var state = getTrustPathGraphState(svg);
+    var rect = svg.getBoundingClientRect();
+    var focusX = typeof clientX === "number" && rect.width > 0 ? (clientX - rect.left) / rect.width : 0.5;
+    var focusY = typeof clientY === "number" && rect.height > 0 ? (clientY - rect.top) / rect.height : 0.5;
+    var nextWidth = state.current.width * factor;
+    var nextHeight = state.current.height * factor;
+    var next = clampTrustPathViewBox(svg, {
+        x: state.current.x + (state.current.width - nextWidth) * focusX,
+        y: state.current.y + (state.current.height - nextHeight) * focusY,
+        width: nextWidth,
+        height: nextHeight,
+    });
+
+    state.current = next;
+    setSVGViewBox(svg, next);
+}
+
+function resetTrustPathGraph(svg) {
+    var state = getTrustPathGraphState(svg);
+    state.current = Object.assign({}, state.initial);
+    setSVGViewBox(svg, state.current);
+}
+
+function findTrustPathSVG(control) {
+    var section = control && control.closest ? control.closest(".section-card") : null;
+    return section ? section.querySelector(".trust-path-mermaid svg") : null;
+}
+
+function initializeTrustPathPanZoom(svg) {
+    if (!svg || svg.dataset.trustPathPanZoom === "ready") {
+        return;
+    }
+    svg.dataset.trustPathPanZoom = "ready";
+    svg.setAttribute("role", "img");
+    svg.style.touchAction = "none";
+    getTrustPathGraphState(svg);
+
+    var drag = {
+        active: false,
+        moved: false,
+        pointerId: null,
+        clientX: 0,
+        clientY: 0,
+    };
+
+    svg.addEventListener("pointerdown", function (evt) {
+        if (evt.button !== 0) {
+            return;
+        }
+        if (evt.target && evt.target.closest && evt.target.closest(".node")) {
+            drag.active = false;
+            drag.moved = false;
+            return;
+        }
+        drag.active = true;
+        drag.moved = false;
+        drag.pointerId = evt.pointerId;
+        drag.clientX = evt.clientX;
+        drag.clientY = evt.clientY;
+        evt.currentTarget.classList.add("is-panning");
+        evt.currentTarget.setPointerCapture(evt.pointerId);
+    });
+
+    svg.addEventListener("pointermove", function (evt) {
+        if (!drag.active || drag.pointerId !== evt.pointerId) {
+            return;
+        }
+        var svgEl = evt.currentTarget;
+        var state = getTrustPathGraphState(svgEl);
+        var rect = svgEl.getBoundingClientRect();
+        if (rect.width <= 0 || rect.height <= 0) {
+            return;
+        }
+        var dx = evt.clientX - drag.clientX;
+        var dy = evt.clientY - drag.clientY;
+        if (Math.abs(dx) + Math.abs(dy) > 3) {
+            drag.moved = true;
+        }
+        drag.clientX = evt.clientX;
+        drag.clientY = evt.clientY;
+        state.current = {
+            x: state.current.x - dx * (state.current.width / rect.width),
+            y: state.current.y - dy * (state.current.height / rect.height),
+            width: state.current.width,
+            height: state.current.height,
+        };
+        setSVGViewBox(svgEl, state.current);
+    });
+
+    svg.addEventListener("pointerup", function (evt) {
+        if (drag.active && drag.pointerId === evt.pointerId) {
+            evt.currentTarget.classList.remove("is-panning");
+            drag.active = false;
+        }
+    });
+
+    svg.addEventListener("pointercancel", function (evt) {
+        evt.currentTarget.classList.remove("is-panning");
+        drag.active = false;
+    });
+
+    svg.addEventListener("click", function (evt) {
+        var nodeEl = evt.target && evt.target.closest ? evt.target.closest(".node.interactive") : null;
+        if (nodeEl) {
+            evt.preventDefault();
+            evt.stopImmediatePropagation();
+            drag.moved = false;
+            selectTrustPathCertFromMermaid(getRenderedMermaidNodeID(nodeEl));
+            return;
+        }
+        if (drag.moved) {
+            evt.preventDefault();
+            evt.stopImmediatePropagation();
+            drag.moved = false;
+        }
+    }, true);
+}
+
+function initializeTrustPathGraphControls(scope) {
+    var root = scope || document;
+    var wrappers = root.querySelectorAll ? root.querySelectorAll(".trust-path-mermaid") : [];
+    for (var i = 0; i < wrappers.length; i++) {
+        initializeTrustPathPanZoom(wrappers[i].querySelector("svg"));
+    }
+
+    var controls = root.querySelectorAll ? root.querySelectorAll("[data-graph-action]") : [];
+    for (var j = 0; j < controls.length; j++) {
+        if (controls[j].dataset.graphControls === "ready") {
+            continue;
+        }
+        controls[j].dataset.graphControls = "ready";
+        controls[j].addEventListener("click", function (evt) {
+            var svg = findTrustPathSVG(evt.currentTarget);
+            if (!svg) {
+                return;
+            }
+            if (evt.currentTarget.dataset.graphAction === "zoom-in") {
+                zoomTrustPathGraph(svg, 0.8);
+            } else if (evt.currentTarget.dataset.graphAction === "zoom-out") {
+                zoomTrustPathGraph(svg, 1.25);
+            } else {
+                resetTrustPathGraph(svg);
+            }
+        });
+    }
 }
 
 function copyPEM(button, certHash) {
@@ -140,6 +392,25 @@ function findRenderedMermaidNodes(nodeId) {
         }
     }
     return matches;
+}
+
+function getRenderedMermaidNodeID(nodeEl) {
+    if (!nodeEl) {
+        return "";
+    }
+    if (nodeEl.dataset && nodeEl.dataset.id) {
+        return nodeEl.dataset.id;
+    }
+
+    var mapEntries = document.querySelectorAll(".tp-node-map");
+    var renderedID = nodeEl.id || "";
+    for (var i = 0; i < mapEntries.length; i++) {
+        var nodeID = mapEntries[i].dataset.nodeId;
+        if (renderedID === nodeID || renderedID.indexOf("-" + nodeID + "-") !== -1) {
+            return nodeID;
+        }
+    }
+    return renderedID;
 }
 
 function findRenderedMermaidEdges(nodeId) {

--- a/internal/web/tailwind.css
+++ b/internal/web/tailwind.css
@@ -316,11 +316,11 @@ a {
 }
 
 .graph-scroll {
-  @apply overflow-x-auto py-3;
+  @apply py-3;
 }
 
 .graph-center {
-  @apply flex min-w-full justify-center;
+  @apply block min-w-full;
 }
 
 .selected-heading {
@@ -538,7 +538,7 @@ a {
 }
 
 .graph-download-row {
-  @apply flex justify-end pt-1;
+  @apply flex items-center justify-between gap-3 pt-1;
 }
 
 .btn-graph-download {
@@ -547,19 +547,31 @@ a {
   @apply dark:border-slate-600 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700 dark:hover:text-slate-100;
 }
 
+.graph-controls {
+  @apply flex items-center gap-1;
+}
+
+.btn-graph-control {
+  @apply inline-flex h-8 w-8 items-center justify-center rounded-lg border border-slate-300 bg-white text-slate-600;
+  @apply transition-colors hover:bg-slate-100 hover:text-slate-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500;
+  @apply dark:border-slate-600 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700 dark:hover:text-slate-100;
+}
+
 .trust-path-mermaid {
-  width: min(100%, 56rem);
-  margin-left: auto;
-  margin-right: auto;
+  width: 100%;
 }
 
 .trust-path-mermaid svg {
   display: block;
-  width: 100%;
-  max-width: 100%;
-  height: auto;
-  margin-left: auto;
-  margin-right: auto;
+  width: 100% !important;
+  max-width: 100% !important;
+  height: clamp(24rem, 54vh, 38rem) !important;
+  cursor: grab;
+  user-select: none;
+}
+
+.trust-path-mermaid svg.is-panning {
+  cursor: grabbing;
 }
 
 .trust-path-mermaid .mermaid {

--- a/internal/web/templates/results.html
+++ b/internal/web/templates/results.html
@@ -64,6 +64,17 @@
             </div>
         </div>
         <div class="graph-download-row">
+            <div class="graph-controls" aria-label="Trust path diagram controls">
+                <button type="button" class="btn-graph-control" data-graph-action="zoom-in" title="Zoom in" aria-label="Zoom in">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M10 10m-7 0a7 7 0 1 0 14 0a7 7 0 1 0 -14 0" /><path d="M7 10l6 0" /><path d="M10 7l0 6" /><path d="M21 21l-6 -6" /></svg>
+                </button>
+                <button type="button" class="btn-graph-control" data-graph-action="zoom-out" title="Zoom out" aria-label="Zoom out">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M10 10m-7 0a7 7 0 1 0 14 0a7 7 0 1 0 -14 0" /><path d="M7 10l6 0" /><path d="M21 21l-6 -6" /></svg>
+                </button>
+                <button type="button" class="btn-graph-control" data-graph-action="reset" title="Reset view" aria-label="Reset view">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M20 11a8.1 8.1 0 0 0 -15.5 -2m-.5 -4v4h4" /><path d="M4 13a8.1 8.1 0 0 0 15.5 2m.5 4v-4h-4" /></svg>
+                </button>
+            </div>
             <a class="btn-graph-download" href="{{.DownloadURL}}" title="Download all certificates as PEM">
                 <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M4 17v2a2 2 0 0 0 2 2h12a2 2 0 0 0 2 -2v-2" /><path d="M7 11l5 5l5 -5" /><path d="M12 4l0 12" /></svg>
                 <span>Download PEM</span>


### PR DESCRIPTION
## Summary

Add interactive pan and zoom functionality to the Mermaid trust path diagram with zoom buttons, reset control, and mouse/touch drag panning.

### Changes

- Add zoom in, zoom out, and reset buttons to the graph controls row
- Implement pan support via pointer events with grab cursor feedback
- Clamp zoom range to prevent overly small or large views
- Fit initial viewBox to container aspect ratio
- Allow clicking certificate nodes to select them from the diagram

### Files changed

- `internal/web/templates/results.html` - Add zoom/pan control buttons
- `internal/web/static/js/script.js` - Pan/zoom logic and event handlers
- `internal/web/tailwind.css` - Tailwind utility classes for controls
- `internal/web/static/css/style.css` - Embedded CSS output