### PR TITLE
reorganize cert chain layout and modernize Go code

### DIFF
--- a/internal/certutil/certutil.go
+++ b/internal/certutil/certutil.go
@@ -7,6 +7,7 @@ import (
 	"crypto/x509"
 	"encoding/binary"
 	"encoding/pem"
+	"strings"
 	"time"
 )
 
@@ -152,11 +153,11 @@ func ParseChain(certs []*x509.Certificate) *ChainInfo {
 
 // ChainToPEM returns the PEM-encoded representation of all certificates in the chain.
 func ChainToPEM(certs []*CertInfo) string {
-	var result string
+	var result strings.Builder
 	for _, cert := range certs {
-		result += cert.PEM()
+		result.WriteString(cert.PEM())
 	}
-	return result
+	return result.String()
 }
 
 // DERToPEM converts DER-encoded certificate bytes to PEM format.

--- a/internal/cmd/crawl_domains.go
+++ b/internal/cmd/crawl_domains.go
@@ -104,10 +104,7 @@ func CrawlDomains(ctx context.Context, cfg *CrawlDomainsConfig) error {
 	repo := db.NewRepository(database)
 
 	// Calculate effective age: (age_days * 24h) - 1h
-	effectiveAge := time.Duration(cfg.AgeDays*24)*time.Hour - 1*time.Hour
-	if effectiveAge < 0 {
-		effectiveAge = 0
-	}
+	effectiveAge := max(time.Duration(cfg.AgeDays*24)*time.Hour-1*time.Hour, 0)
 
 	logger.Debug("effective age threshold", "effective_age", effectiveAge.String())
 

--- a/internal/cmd/ingest_roots_test.go
+++ b/internal/cmd/ingest_roots_test.go
@@ -18,7 +18,7 @@ func generateTestPEMBundle(t *testing.T, count int) []byte {
 	t.Helper()
 
 	var bundle []byte
-	for i := 0; i < count; i++ {
+	for i := range count {
 		cert := generateTestCert(t, fmt.Sprintf("test-cert-%d", i))
 		pemBlock := &pem.Block{
 			Type:  "CERTIFICATE",

--- a/internal/cmd/ingest_toplist.go
+++ b/internal/cmd/ingest_toplist.go
@@ -143,10 +143,7 @@ func IngestToplist(ctx context.Context, cfg *IngestToplistConfig) error {
 	totalUpdated := 0
 
 	for i := 0; i < len(validDomains); i += batchSize {
-		end := i + batchSize
-		if end > len(validDomains) {
-			end = len(validDomains)
-		}
+		end := min(i+batchSize, len(validDomains))
 		batch := validDomains[i:end]
 		batchNum := i/batchSize + 1
 

--- a/internal/db/auto_crawl_repository.go
+++ b/internal/db/auto_crawl_repository.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/UnitVectorY-Labs/cert-observatory/internal/certutil"
@@ -435,16 +436,13 @@ func (r *Repository) CheckCertificatesExist(ctx context.Context, hashes [][]byte
 	// Check in batches of 100 using IN clause
 	batchSize := 100
 	for i := 0; i < len(hashes); i += batchSize {
-		end := i + batchSize
-		if end > len(hashes) {
-			end = len(hashes)
-		}
+		end := min(i+batchSize, len(hashes))
 
 		batch := hashes[i:end]
 
 		// Build query with placeholders for IN clause
 		placeholders := make([]string, len(batch))
-		args := make([]interface{}, len(batch))
+		args := make([]any, len(batch))
 		for j, hash := range batch {
 			placeholders[j] = fmt.Sprintf("$%d", j+1)
 			args[j] = hash
@@ -480,9 +478,10 @@ func joinStrings(parts []string, sep string) string {
 	if len(parts) == 0 {
 		return ""
 	}
-	result := parts[0]
+	var result strings.Builder
+	result.WriteString(parts[0])
 	for i := 1; i < len(parts); i++ {
-		result += sep + parts[i]
+		result.WriteString(sep + parts[i])
 	}
-	return result
+	return result.String()
 }

--- a/internal/db/repository.go
+++ b/internal/db/repository.go
@@ -360,7 +360,7 @@ func normalizePort(port int) int {
 }
 
 // nullableBytes returns nil if the slice is empty, otherwise returns the slice.
-func nullableBytes(b []byte) interface{} {
+func nullableBytes(b []byte) any {
 	if len(b) == 0 {
 		return nil
 	}

--- a/internal/db/repository_test.go
+++ b/internal/db/repository_test.go
@@ -439,7 +439,7 @@ func TestRepository_SuccessAfterFailureResetsCounter(t *testing.T) {
 	domain := "recovers.example.com"
 
 	// Record some failures
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		err := repo.RecordFailedCrawl(ctx, domain, time.Now(), db.CrawlModeStandard)
 		if err != nil {
 			t.Fatalf("RecordFailedCrawl failed: %v", err)

--- a/internal/domain/domain.go
+++ b/internal/domain/domain.go
@@ -153,8 +153,8 @@ func NormalizeAndValidateTarget(input string, allowPort bool) (*Target, error) {
 	}
 
 	// Validate each label
-	labels := strings.Split(normalized, ".")
-	for _, label := range labels {
+	labels := strings.SplitSeq(normalized, ".")
+	for label := range labels {
 		if len(label) == 0 {
 			return nil, ErrDomainInvalidLabel
 		}

--- a/internal/web/chain_graph.go
+++ b/internal/web/chain_graph.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"maps"
 	"strings"
 	"time"
 )
@@ -238,10 +239,7 @@ func assignCrossSignedMarkers(root *ChainGraphNode) []string {
 	}
 	sortCrossGroupsByFirstSeen(ordered)
 
-	markerCount := len(ordered)
-	if markerCount > len(crossSignedMarkers) {
-		markerCount = len(crossSignedMarkers)
-	}
+	markerCount := min(len(ordered), len(crossSignedMarkers))
 	usedMarkers := make([]string, 0, markerCount)
 	for i := 0; i < markerCount; i++ {
 		marker := crossSignedMarkers[i]
@@ -452,9 +450,7 @@ func (b *chainGraphBuilder) buildNode(cert *CertificateResult, visited map[strin
 		for _, issuer := range issuers {
 			// Clone visited set for each branch to allow divergent paths
 			branchVisited := make(map[string]bool, len(visited))
-			for k, v := range visited {
-				branchVisited[k] = v
-			}
+			maps.Copy(branchVisited, visited)
 			issuerNode := b.buildNode(issuer, branchVisited, depth+1)
 			if issuerNode != nil {
 				node.Issuers = append(node.Issuers, issuerNode)

--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -664,7 +664,7 @@ func generateLockID() string {
 	if _, err := rand.Read(b); err != nil {
 		// This should never happen with crypto/rand, but handle gracefully
 		// Use a timestamp-based fallback
-		b = []byte(fmt.Sprintf("%x", time.Now().UnixNano()))
+		b = fmt.Appendf(nil, "%x", time.Now().UnixNano())
 	}
 	return hex.EncodeToString(b)
 }

--- a/internal/web/static/js/script.js
+++ b/internal/web/static/js/script.js
@@ -475,14 +475,19 @@ function selectTrustPathCert(nodeId, certIdx) {
         activeEdges[j].classList.add("tp-active-edge");
     }
 
-    var chainSection = document.getElementById("chain-view-section");
-    if (chainSection) {
-        chainSection.style.display = "none";
+    var chainHeading = document.getElementById("chain-heading");
+    if (chainHeading) {
+        chainHeading.style.display = "none";
     }
 
     var selectedHeading = document.getElementById("selected-cert-heading");
     if (selectedHeading) {
         selectedHeading.style.display = "block";
+    }
+
+    var chainList = document.getElementById("certificate-chain-list");
+    if (chainList) {
+        chainList.style.display = "none";
     }
 
     var allPanes = document.querySelectorAll(".trust-path-cert-pane");

--- a/internal/web/templates/results.html
+++ b/internal/web/templates/results.html
@@ -84,62 +84,24 @@
             </a>
         </div>
 
-        <div id="selected-cert-heading" class="selected-heading" style="display:none;">
+    </div>
+    {{end}}
+
+    <div id="chain-view-section" class="chain-section">
+        <div id="chain-heading" class="mb-4">
+            <h3 class="chain-heading">
+                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="inline-block align-middle" style="margin-right: 0.4rem;"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M3 7l6 -3l6 3l6 -3v13l-6 3l-6 -3l-6 3z" /><path d="M9 4v13" /><path d="M15 7v13" /></svg>Certificate Chain
+            </h3>
+            <p class="section-copy">The certificate chain as presented by the server during the TLS handshake.</p>
+        </div>
+        <div id="selected-cert-heading" class="mb-4" style="display:none;">
             <h3 class="chain-heading">
                 <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="inline-block align-middle" style="margin-right: 0.4rem;"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M12 15a3 3 0 1 0 6 0a3 3 0 1 0 -6 0" /><path d="M13 17.5v4.5l2 -1.5l2 1.5v-4.5" /><path d="M10 19h-5a2 2 0 0 1 -2 -2v-10c0 -1.1 .9 -2 2 -2h14a2 2 0 0 1 2 2v10a2 2 0 0 1 -1 1.73" /><path d="M6 9l12 0" /><path d="M6 12l3 0" /><path d="M6 15l2 0" /></svg>Selected Certificate
             </h3>
             <p class="section-copy">Viewing a single certificate selected from the trust path above.</p>
         </div>
 
-        {{range $idx, $gc := .ChainGraph.AllCerts}}
-        <div class="trust-path-cert-pane mt-4" id="trust-cert-pane-{{$idx}}" style="display:none;">
-            <div class="cert-card">
-                <div class="cert-content">
-                    <div class="pem-column">
-                        <div class="pem-wrap">
-                            <pre class="pem-block" id="pem-g{{$gc.HashHex}}">{{$gc.PEM}}</pre>
-                            <button type="button" class="btn-copy" onclick="copyPEM(this, 'g{{$gc.HashHex}}')">
-                                <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="inline-block align-middle"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M7 9.667a2.667 2.667 0 0 1 2.667 -2.667h8.666a2.667 2.667 0 0 1 2.667 2.667v8.666a2.667 2.667 0 0 1 -2.667 2.667h-8.666a2.667 2.667 0 0 1 -2.667 -2.667l0 -8.666" /><path d="M4.012 16.737a2.005 2.005 0 0 1 -1.012 -1.737v-10c0 -1.1 .9 -2 2 -2h10c.75 0 1.158 .385 1.5 1" /></svg>
-                                Copy PEM
-                            </button>
-                        </div>
-                    </div>
-                    <div class="details-column" data-cert-tabs>
-                        <div class="cert-tab-list" role="tablist" aria-label="Certificate decode view">
-                            <button type="button" class="cert-tab-button is-active" role="tab" aria-selected="true" data-cert-tab-button="overview" onclick="switchCertDecodeTab(this, 'overview')">Overview</button>
-                            <button type="button" class="cert-tab-button" role="tab" aria-selected="false" data-cert-tab-button="usage" onclick="switchCertDecodeTab(this, 'usage')">Usage</button>
-                            <button type="button" class="cert-tab-button" role="tab" aria-selected="false" data-cert-tab-button="extensions" onclick="switchCertDecodeTab(this, 'extensions')">Extensions</button>
-                            <button type="button" class="cert-tab-button" role="tab" aria-selected="false" data-cert-tab-button="raw" onclick="switchCertDecodeTab(this, 'raw')">Raw</button>
-                        </div>
-                        <div class="cert-tab-panel" data-cert-tab-panel="overview">
-                            {{template "cert-overview-details" $gc}}
-                        </div>
-                        <div class="cert-tab-panel hidden" data-cert-tab-panel="usage">
-                            {{template "cert-usage-details" $gc}}
-                        </div>
-                        <div class="cert-tab-panel hidden" data-cert-tab-panel="extensions">
-                            {{template "cert-extensions-details" $gc}}
-                        </div>
-                        <div class="cert-tab-panel hidden" data-cert-tab-panel="raw">
-                            {{template "cert-raw-details" $gc}}
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
-        {{end}}
-    </div>
-    {{end}}
-
-    <div id="chain-view-section" class="chain-section">
-        <div class="mb-4">
-            <h3 class="chain-heading">
-                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="inline-block align-middle" style="margin-right: 0.4rem;"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M3 7l6 -3l6 3l6 -3v13l-6 3l-6 -3l-6 3z" /><path d="M9 4v13" /><path d="M15 7v13" /></svg>Certificate Chain
-            </h3>
-            <p class="section-copy">The certificate chain as presented by the server during the TLS handshake.</p>
-        </div>
-
-        <div class="space-y-4">
+        <div id="certificate-chain-list" class="space-y-4">
             {{range $index, $cert := .Chain}}
             <div class="cert-card">
                 <div class="cert-top">
@@ -184,6 +146,46 @@
             </div>
             {{end}}
         </div>
+
+        {{if .ChainGraph}}
+        {{range $idx, $gc := .ChainGraph.AllCerts}}
+        <div class="trust-path-cert-pane" id="trust-cert-pane-{{$idx}}" style="display:none;">
+            <div class="cert-card">
+                <div class="cert-content">
+                    <div class="pem-column">
+                        <div class="pem-wrap">
+                            <pre class="pem-block" id="pem-g{{$gc.HashHex}}">{{$gc.PEM}}</pre>
+                            <button type="button" class="btn-copy" onclick="copyPEM(this, 'g{{$gc.HashHex}}')">
+                                <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="inline-block align-middle"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M7 9.667a2.667 2.667 0 0 1 2.667 -2.667h8.666a2.667 2.667 0 0 1 2.667 2.667v8.666a2.667 2.667 0 0 1 -2.667 2.667h-8.666a2.667 2.667 0 0 1 -2.667 -2.667l0 -8.666" /><path d="M4.012 16.737a2.005 2.005 0 0 1 -1.012 -1.737v-10c0 -1.1 .9 -2 2 -2h10c.75 0 1.158 .385 1.5 1" /></svg>
+                                Copy PEM
+                            </button>
+                        </div>
+                    </div>
+                    <div class="details-column" data-cert-tabs>
+                        <div class="cert-tab-list" role="tablist" aria-label="Certificate decode view">
+                            <button type="button" class="cert-tab-button is-active" role="tab" aria-selected="true" data-cert-tab-button="overview" onclick="switchCertDecodeTab(this, 'overview')">Overview</button>
+                            <button type="button" class="cert-tab-button" role="tab" aria-selected="false" data-cert-tab-button="usage" onclick="switchCertDecodeTab(this, 'usage')">Usage</button>
+                            <button type="button" class="cert-tab-button" role="tab" aria-selected="false" data-cert-tab-button="extensions" onclick="switchCertDecodeTab(this, 'extensions')">Extensions</button>
+                            <button type="button" class="cert-tab-button" role="tab" aria-selected="false" data-cert-tab-button="raw" onclick="switchCertDecodeTab(this, 'raw')">Raw</button>
+                        </div>
+                        <div class="cert-tab-panel" data-cert-tab-panel="overview">
+                            {{template "cert-overview-details" $gc}}
+                        </div>
+                        <div class="cert-tab-panel hidden" data-cert-tab-panel="usage">
+                            {{template "cert-usage-details" $gc}}
+                        </div>
+                        <div class="cert-tab-panel hidden" data-cert-tab-panel="extensions">
+                            {{template "cert-extensions-details" $gc}}
+                        </div>
+                        <div class="cert-tab-panel hidden" data-cert-tab-panel="raw">
+                            {{template "cert-raw-details" $gc}}
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        {{end}}
+        {{end}}
     </div>
 </div>
 {{end}}

--- a/internal/web/types.go
+++ b/internal/web/types.go
@@ -251,7 +251,7 @@ func formatAdvancedCertificate(cert *x509.Certificate) string {
 	return strings.TrimRight(b.String(), "\n")
 }
 
-func writeAdvancedLine(b *strings.Builder, indent int, format string, args ...interface{}) {
+func writeAdvancedLine(b *strings.Builder, indent int, format string, args ...any) {
 	b.WriteString(strings.Repeat("    ", indent))
 	fmt.Fprintf(b, format, args...)
 	b.WriteByte('\n')
@@ -263,10 +263,7 @@ func writeWrappedHex(b *strings.Builder, indent int, data []byte, perLine int) {
 		return
 	}
 	for start := 0; start < len(data); start += perLine {
-		end := start + perLine
-		if end > len(data) {
-			end = len(data)
-		}
+		end := min(start+perLine, len(data))
 		writeAdvancedLine(b, indent, "%s", formatHexBytes(data[start:end]))
 	}
 }
@@ -280,7 +277,7 @@ func writeAdvancedExtension(b *strings.Builder, ext pkix.Extension, cert *x509.C
 	writeAdvancedLine(b, 3, "%s%s:", name, critical)
 
 	if formatted, ok := formatKnownExtension(ext, cert); ok {
-		for _, line := range strings.Split(formatted, "\n") {
+		for line := range strings.SplitSeq(formatted, "\n") {
 			writeAdvancedLine(b, 4, "%s", line)
 		}
 		return
@@ -407,11 +404,11 @@ func formatSubjectAlternativeNames(cert *x509.Certificate) string {
 }
 
 func extractCN(dn string) string {
-	parts := strings.Split(dn, ",")
-	for _, part := range parts {
+	parts := strings.SplitSeq(dn, ",")
+	for part := range parts {
 		part = strings.TrimSpace(part)
-		if strings.HasPrefix(part, "CN=") {
-			return strings.TrimPrefix(part, "CN=")
+		if after, ok := strings.CutPrefix(part, "CN="); ok {
+			return after
 		}
 	}
 	return dn

--- a/internal/web/types_test.go
+++ b/internal/web/types_test.go
@@ -14,7 +14,7 @@ import (
 	"time"
 )
 
-func generateTestCert(t *testing.T, pub interface{}, priv interface{}) *x509.Certificate {
+func generateTestCert(t *testing.T, pub any, priv any) *x509.Certificate {
 	t.Helper()
 
 	tmpl := &x509.Certificate{


### PR DESCRIPTION
## Changes

Two independent sets of changes, committed separately:

### 1. Reorganize cert chain layout and selected cert pane visibility
- Rearrange the certificate chain section so the chain heading and certificate list appear before the selected cert heading
- When a certificate is selected from the trust path, hide both the chain heading and the certificate list to reduce visual clutter

### 2. Modernize Go code for 1.21+ features
- Use strings.Builder instead of string concatenation
- Replace interface{} with any
- Use min/max builtins instead of manual comparisons
- Use strings.SplitSeq instead of strings.Split for iteration
- Use maps.Copy instead of manual map cloning
- Use strings.CutPrefix instead of strings.HasPrefix + strings.TrimPrefix
- Use fmt.Appendf for byte formatting
- Use for-range over integer for simple loops