### PR TITLE
Add chain/all download scope options for certificate PEM bundles

### DIFF
--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -172,7 +172,7 @@ func (s *Server) handleManualCert(w http.ResponseWriter, r *http.Request) {
 	// Pass all uploaded certs so they are all marked "in chain" in the Mermaid diagram,
 	// matching the grouping used when a server returns multiple certificates.
 	data.ChainGraph = buildChainGraph(r.Context(), s.repo, uploaded, filters)
-	data.DownloadURL = buildManualDownloadURL(hex.EncodeToString(uploaded[0].CertHash), filters)
+	data.AllDownloadURL = buildManualDownloadURL(hex.EncodeToString(uploaded[0].CertHash), filters)
 
 	s.renderManualResults(w, r, data)
 }
@@ -574,7 +574,8 @@ func (s *Server) renderCachedResults(w http.ResponseWriter, r *http.Request, res
 
 	// Build the chain graph from the chain certificates
 	data.ChainGraph = buildChainGraph(r.Context(), s.repo, result.Chain, filters)
-	data.DownloadURL = buildNormalDownloadURL(result.Domain, result.Port, filters)
+	data.ChainDownloadURL = buildNormalDownloadURL(result.Domain, result.Port, filters, "chain")
+	data.AllDownloadURL = buildNormalDownloadURL(result.Domain, result.Port, filters, "all")
 
 	s.renderResults(w, r, data)
 }
@@ -601,7 +602,8 @@ func (s *Server) renderFreshResults(w http.ResponseWriter, r *http.Request, resu
 
 	// Build the chain graph from the chain certificates
 	data.ChainGraph = buildChainGraph(r.Context(), s.repo, result.Chain, filters)
-	data.DownloadURL = buildNormalDownloadURL(result.Domain, result.Port, filters)
+	data.ChainDownloadURL = buildNormalDownloadURL(result.Domain, result.Port, filters, "chain")
+	data.AllDownloadURL = buildNormalDownloadURL(result.Domain, result.Port, filters, "all")
 
 	s.renderResults(w, r, data)
 }
@@ -746,9 +748,12 @@ func formatDuration(d time.Duration) string {
 }
 
 // buildNormalDownloadURL constructs the server-side download URL for a domain.
-func buildNormalDownloadURL(domainName string, port int, filters ChainGraphFilters) string {
+func buildNormalDownloadURL(domainName string, port int, filters ChainGraphFilters, scope string) string {
 	params := url.Values{}
 	params.Set("domain", domainName)
+	if scope != "" {
+		params.Set("scope", scope)
+	}
 	if port != 0 && port != 443 {
 		params.Set("port", fmt.Sprintf("%d", port))
 	}
@@ -788,14 +793,23 @@ func sanitizeDownloadFilename(name string) string {
 	return result
 }
 
-// handleDownload serves a PEM bundle of all certificates in the trust path graph.
+// handleDownload serves a PEM bundle for the presented chain or all certificates in the trust path graph.
 func (s *Server) handleDownload(w http.ResponseWriter, r *http.Request) {
 	domainParam := r.URL.Query().Get("domain")
 	certHashHex := r.URL.Query().Get("cert")
+	scope := r.URL.Query().Get("scope")
+	if scope == "" {
+		scope = "all"
+	}
+	if scope != "chain" && scope != "all" {
+		http.Error(w, "Invalid download scope", http.StatusBadRequest)
+		return
+	}
 
 	var chainCerts []*CertificateResult
 	var filters ChainGraphFilters
 	var filenameBase string
+	var filenameSuffix string
 
 	if domainParam != "" {
 		target, err := domain.NormalizeAndValidateTarget(domainParam, false)
@@ -821,7 +835,12 @@ func (s *Server) handleDownload(w http.ResponseWriter, r *http.Request) {
 			ShowExpired:       r.URL.Query().Get("showExpired") == "true",
 		}
 		filenameBase = formatTarget(target.Domain, target.Port)
+		filenameSuffix = "chain"
 	} else if certHashHex != "" {
+		if scope == "chain" {
+			http.Error(w, "Chain download is only available for domain results", http.StatusBadRequest)
+			return
+		}
 		hash, err := hex.DecodeString(certHashHex)
 		if err != nil || len(hash) != 32 {
 			http.Error(w, "Invalid cert hash", http.StatusBadRequest)
@@ -842,19 +861,31 @@ func (s *Server) handleDownload(w http.ResponseWriter, r *http.Request) {
 		if filenameBase == "" {
 			filenameBase = "certificate"
 		}
+		filenameSuffix = "certificates"
 	} else {
 		http.Error(w, "Missing domain or cert parameter", http.StatusBadRequest)
 		return
 	}
 
-	graph := buildChainGraph(r.Context(), s.repo, chainCerts, filters)
-	if graph == nil || len(graph.AllCerts) == 0 {
+	var downloadCerts []*CertViewData
+	if scope == "chain" {
+		for _, cert := range chainCerts {
+			downloadCerts = append(downloadCerts, certToViewData(cert))
+		}
+	} else {
+		graph := buildChainGraph(r.Context(), s.repo, chainCerts, filters)
+		if graph != nil {
+			downloadCerts = graph.AllCerts
+		}
+		filenameSuffix = "certificates"
+	}
+	if len(downloadCerts) == 0 {
 		http.Error(w, "No certificates found", http.StatusNotFound)
 		return
 	}
 
 	var buf strings.Builder
-	for _, cert := range graph.AllCerts {
+	for _, cert := range downloadCerts {
 		cn := cert.SubjectCN
 		if cn == "" {
 			cn = cert.SubjectDN
@@ -869,7 +900,7 @@ func (s *Server) handleDownload(w http.ResponseWriter, r *http.Request) {
 	}
 
 	safeBase := sanitizeDownloadFilename(filenameBase)
-	filename := safeBase + "-certificates.pem"
+	filename := safeBase + "-" + filenameSuffix + ".pem"
 
 	w.Header().Set("Content-Type", "application/x-pem-file")
 	// sanitizeDownloadFilename strips all characters that could break the quoted filename

--- a/internal/web/handlers_test.go
+++ b/internal/web/handlers_test.go
@@ -1427,6 +1427,55 @@ func TestHandleDownload_DomainWithChain(t *testing.T) {
 	}
 }
 
+func TestHandleDownload_DomainWithChainScope(t *testing.T) {
+	pemStr := "-----BEGIN CERTIFICATE-----\nchain\n-----END CERTIFICATE-----\n"
+	repo := &mockRepository{
+		domainResult: &DomainResult{
+			Domain:   "github.com",
+			HasChain: true,
+			Chain: []*CertificateResult{
+				{
+					CertHash:  make([]byte, 32),
+					PEM:       pemStr,
+					Subject:   "CN=github.com",
+					NotBefore: time.Now().Add(-24 * time.Hour),
+					NotAfter:  time.Now().Add(365 * 24 * time.Hour),
+				},
+			},
+		},
+	}
+	server, err := New(DefaultConfig(), repo, &mockCrawler{})
+	if err != nil {
+		t.Fatalf("create server: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/download?domain=github.com&scope=chain", nil)
+	w := httptest.NewRecorder()
+	server.handleDownload(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if cd := w.Header().Get("Content-Disposition"); !strings.Contains(cd, "github.com-chain.pem") {
+		t.Errorf("expected filename github.com-chain.pem in Content-Disposition, got %s", cd)
+	}
+}
+
+func TestHandleDownload_InvalidScope(t *testing.T) {
+	server, err := New(DefaultConfig(), &mockRepository{}, &mockCrawler{})
+	if err != nil {
+		t.Fatalf("create server: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/download?domain=github.com&scope=invalid", nil)
+	w := httptest.NewRecorder()
+	server.handleDownload(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for invalid scope, got %d", w.Code)
+	}
+}
+
 func TestHandleDownload_InvalidCertHash(t *testing.T) {
 	server, err := New(DefaultConfig(), &mockRepository{}, &mockCrawler{})
 	if err != nil {
@@ -1464,9 +1513,12 @@ func TestSanitizeDownloadFilename(t *testing.T) {
 }
 
 func TestBuildNormalDownloadURL(t *testing.T) {
-	url := buildNormalDownloadURL("github.com", 443, ChainGraphFilters{ShowNonChainCerts: true, ShowExpired: false})
+	url := buildNormalDownloadURL("github.com", 443, ChainGraphFilters{ShowNonChainCerts: true, ShowExpired: false}, "all")
 	if !strings.Contains(url, "domain=github.com") {
 		t.Errorf("expected domain param in URL, got %s", url)
+	}
+	if !strings.Contains(url, "scope=all") {
+		t.Errorf("expected scope param in URL, got %s", url)
 	}
 	if !strings.Contains(url, "showNonChainCerts=true") {
 		t.Errorf("expected showNonChainCerts param in URL, got %s", url)
@@ -1475,9 +1527,12 @@ func TestBuildNormalDownloadURL(t *testing.T) {
 		t.Errorf("expected no showExpired param when false, got %s", url)
 	}
 
-	url = buildNormalDownloadURL("github.com", 8443, ChainGraphFilters{})
+	url = buildNormalDownloadURL("github.com", 8443, ChainGraphFilters{}, "chain")
 	if !strings.Contains(url, "port=8443") {
 		t.Errorf("expected port param in URL, got %s", url)
+	}
+	if !strings.Contains(url, "scope=chain") {
+		t.Errorf("expected scope param in URL, got %s", url)
 	}
 }
 

--- a/internal/web/static/css/style.css
+++ b/internal/web/static/css/style.css
@@ -261,9 +261,6 @@
   .mt-0\.5 {
     margin-top: calc(var(--spacing) * 0.5);
   }
-  .mt-4 {
-    margin-top: calc(var(--spacing) * 4);
-  }
   .mb-3 {
     margin-bottom: calc(var(--spacing) * 3);
   }
@@ -2039,6 +2036,11 @@ a {
   justify-content: space-between;
   gap: calc(var(--spacing) * 3);
   padding-top: calc(var(--spacing) * 1);
+}
+.graph-download-actions {
+  display: flex;
+  align-items: center;
+  gap: calc(var(--spacing) * 2);
 }
 .btn-graph-download {
   display: inline-flex;

--- a/internal/web/tailwind.css
+++ b/internal/web/tailwind.css
@@ -541,6 +541,10 @@ a {
   @apply flex items-center justify-between gap-3 pt-1;
 }
 
+.graph-download-actions {
+  @apply flex items-center gap-2;
+}
+
 .btn-graph-download {
   @apply inline-flex items-center gap-1.5 rounded-lg border border-slate-300 bg-white px-3 py-1.5 text-xs font-semibold text-slate-600;
   @apply transition-colors hover:bg-slate-100 hover:text-slate-900;

--- a/internal/web/templates/results.html
+++ b/internal/web/templates/results.html
@@ -78,10 +78,18 @@
                     <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M20 11a8.1 8.1 0 0 0 -15.5 -2m-.5 -4v4h4" /><path d="M4 13a8.1 8.1 0 0 0 15.5 2m.5 4v-4h-4" /></svg>
                 </button>
             </div>
-            <a class="btn-graph-download" href="{{.DownloadURL}}" title="Download all certificates as PEM">
-                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M4 17v2a2 2 0 0 0 2 2h12a2 2 0 0 0 2 -2v-2" /><path d="M7 11l5 5l5 -5" /><path d="M12 4l0 12" /></svg>
-                <span>Download PEM</span>
-            </a>
+            <div class="graph-download-actions" aria-label="Download PEM certificates">
+                {{if and (not .IsManual) .ChainDownloadURL}}
+                <a class="btn-graph-download" href="{{.ChainDownloadURL}}" title="Download presented chain certificates as PEM">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M4 17v2a2 2 0 0 0 2 2h12a2 2 0 0 0 2 -2v-2" /><path d="M7 11l5 5l5 -5" /><path d="M12 4l0 12" /></svg>
+                    <span>Chain</span>
+                </a>
+                {{end}}
+                <a class="btn-graph-download" href="{{.AllDownloadURL}}" title="Download all graph certificates as PEM">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M4 17v2a2 2 0 0 0 2 2h12a2 2 0 0 0 2 -2v-2" /><path d="M7 11l5 5l5 -5" /><path d="M12 4l0 12" /></svg>
+                    <span>All</span>
+                </a>
+            </div>
         </div>
 
     </div>

--- a/internal/web/types.go
+++ b/internal/web/types.go
@@ -120,8 +120,10 @@ type ResultsViewData struct {
 	ChainGraph *ChainGraphData
 	// IsManual indicates the result was produced from a manually uploaded PEM certificate.
 	IsManual bool
-	// DownloadURL is the server-side URL for downloading all graph certificates as a PEM bundle.
-	DownloadURL string
+	// ChainDownloadURL is the server-side URL for downloading only the presented certificate chain.
+	ChainDownloadURL string
+	// AllDownloadURL is the server-side URL for downloading all graph certificates as a PEM bundle.
+	AllDownloadURL string
 }
 
 // certToViewData converts a CertificateResult to CertViewData.


### PR DESCRIPTION
## Summary

Split the single **Download PEM** button into two separate buttons: **Chain** and **All**.

- **Chain** — downloads only the presented certificate chain as a PEM bundle
- **All** — downloads all certificates in the trust path graph as a PEM bundle

## Changes

- **handlers.go** — Added `scope` parameter to `buildNormalDownloadURL()` and `handleDownload()`. Validates scope is `chain` or `all`. Chain downloads are only available for domain results (not manual uploads).
- **types.go** — Replaced `DownloadURL` with `ChainDownloadURL` and `AllDownloadURL` on `ResultsViewData`.
- **results.html** — Replaced single download link with a `graph-download-actions` flex container holding two buttons.
- **style.css / tailwind.css** — Added `graph-download-actions` utility class for the button layout.
- **handlers_test.go** — Added tests for chain scope download and invalid scope validation.
