### PR TITLE
Remove retired goreportcard badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://opensource.org/licenses/MIT) [![Active](https://img.shields.io/badge/Status-Active-green)](https://guide.unitvectorylabs.com/bestpractices/status/#active)
- [![Go Report Card](https://goreportcard.com/badge/github.com/UnitVectorY-Labs/cert-observatory)](https://goreportcard.com/report/github.com/UnitVectorY-Labs/cert-observatory)
 
 # cert-observatory
 


### PR DESCRIPTION
goreportcard.com has been retired. Removing the badge.